### PR TITLE
Make ReadItem: CopyOnto<Self>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,3 @@ default = ["serde"]
 debug = 2
 codegen-units = 1
 lto = true
-
-[[bench]]
-name = "bench"
-harness = false

--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -16,7 +16,7 @@ impl<T> Default for MirrorRegion<T> {
     }
 }
 
-impl<T: Index> Region for MirrorRegion<T> {
+impl<T: Index + CopyOnto<Self>> Region for MirrorRegion<T> {
     type ReadItem<'a> = T where T: 'a;
     type Index = T;
 

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::impls::slice_copy::CopyRegion;
-use crate::{Containerized, CopyOnto, Region, ReserveItems, SliceRegion};
+use crate::{Containerized, CopyOnto, Region, ReserveItems};
 
 /// A region to store strings and read `&str`.
 #[derive(Default, Debug, Clone)]
@@ -13,7 +13,7 @@ pub struct StringRegion {
 
 impl Region for StringRegion {
     type ReadItem<'a> = &'a str where Self: 'a ;
-    type Index = <SliceRegion<CopyRegion<u8>> as Region>::Index;
+    type Index = <CopyRegion<u8> as Region>::Index;
 
     #[inline]
     fn index(&self, index: Self::Index) -> Self::ReadItem<'_> {


### PR DESCRIPTION
This requires us to change the read item for slice region to not conflict with the tuple implementations.