### PR TITLE
Remove reserve_items from CopyOnto

### DIFF
--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -51,26 +51,12 @@ macro_rules! implement_for {
             fn copy_onto(self, _target: &mut MirrorRegion<Self>) -> $index_type {
                 self
             }
-
-            #[inline(always)]
-            fn reserve_items<I>(_target: &mut MirrorRegion<Self>, _items: I)
-            where
-                I: Iterator<Item = Self> + Clone,
-            {
-            }
         }
 
         impl<'a> CopyOnto<MirrorRegion<$index_type>> for &'a $index_type {
             #[inline(always)]
             fn copy_onto(self, _target: &mut MirrorRegion<$index_type>) -> $index_type {
                 *self
-            }
-
-            #[inline(always)]
-            fn reserve_items<I>(_target: &mut MirrorRegion<$index_type>, _items: I)
-            where
-                I: Iterator<Item = Self> + Clone,
-            {
             }
         }
 

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -64,14 +64,6 @@ where
             Err(e) => Err(e.copy_onto(&mut target.errs)),
         }
     }
-
-    fn reserve_items<I>(_target: &mut ResultRegion<TC, EC>, _items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        // CopyOnto::reserve_items(&mut target.oks, items.clone().flat_map(|r| r.ok()));
-        // CopyOnto::reserve_items(&mut target.errs, items.flat_map(|r| r.err()));
-    }
 }
 
 impl<'a, T: 'a, TC, E: 'a, EC> CopyOnto<ResultRegion<TC, EC>> for &'a Result<T, E>
@@ -90,17 +82,6 @@ where
             Ok(t) => Ok(t.copy_onto(&mut target.oks)),
             Err(e) => Err(e.copy_onto(&mut target.errs)),
         }
-    }
-
-    fn reserve_items<I>(target: &mut ResultRegion<TC, EC>, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        CopyOnto::reserve_items(&mut target.oks, items.clone().flat_map(|r| r.as_ref().ok()));
-        CopyOnto::reserve_items(
-            &mut target.errs,
-            items.clone().flat_map(|r| r.as_ref().err()),
-        );
     }
 }
 

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -115,14 +115,6 @@ where
             .extend(self.iter().map(|t| t.copy_onto(&mut target.inner)));
         (start, target.slices.len())
     }
-
-    fn reserve_items<I>(target: &mut SliceRegion<C>, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        target.slices.reserve(items.clone().map(|i| i.len()).sum());
-        CopyOnto::reserve_items(&mut target.inner, items.flat_map(|i| i.iter()));
-    }
 }
 
 impl<'a, T, R: Region> ReserveItems<SliceRegion<R>> for &'a [T]
@@ -147,13 +139,6 @@ where
     fn copy_onto(self, target: &mut SliceRegion<C>) -> <SliceRegion<C> as Region>::Index {
         self.as_slice().copy_onto(target)
     }
-
-    fn reserve_items<I>(target: &mut SliceRegion<C>, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        CopyOnto::reserve_items(target, items.map(Deref::deref))
-    }
 }
 
 impl<'a, T: 'a, R: Region> ReserveItems<SliceRegion<R>> for &'a Vec<T>
@@ -177,13 +162,6 @@ where
     fn copy_onto(self, target: &mut SliceRegion<C>) -> <SliceRegion<C> as Region>::Index {
         self.as_slice().copy_onto(target)
     }
-
-    fn reserve_items<I>(_target: &mut SliceRegion<C>, _items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        //CopyOnto::reserve_items(target, items.map(Deref::deref))
-    }
 }
 
 impl<'a, C: Region + 'a> CopyOnto<SliceRegion<C>> for ReadSlice<'a, C>
@@ -200,19 +178,6 @@ where
                 .map(|&index| container.index(index).copy_onto(&mut target.inner)),
         );
         (start, target.slices.len())
-    }
-
-    fn reserve_items<I>(target: &mut SliceRegion<C>, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        target
-            .slices
-            .reserve(items.clone().map(|ReadSlice(_c, is)| is.len()).sum());
-        CopyOnto::reserve_items(
-            &mut target.inner,
-            items.flat_map(|ReadSlice(c, is)| is.iter().map(|i| c.index(*i))),
-        )
     }
 }
 

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -50,13 +50,6 @@ where
         target.slices.extend(self);
         (start, target.slices.len())
     }
-
-    fn reserve_items<I>(target: &mut CopyRegion<T>, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        target.slices.reserve(items.clone().map(|i| i.len()).sum());
-    }
 }
 
 impl<T: Copy> ReserveItems<CopyRegion<T>> for &[T] {

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -43,13 +43,6 @@ impl CopyOnto<StringRegion> for &String {
     fn copy_onto(self, target: &mut StringRegion) -> <StringRegion as Region>::Index {
         self.as_str().copy_onto(target)
     }
-
-    fn reserve_items<I>(target: &mut StringRegion, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        CopyOnto::reserve_items(target, items.map(String::as_str));
-    }
 }
 
 impl ReserveItems<StringRegion> for &String {
@@ -66,26 +59,12 @@ impl CopyOnto<StringRegion> for &str {
     fn copy_onto(self, target: &mut StringRegion) -> <StringRegion as Region>::Index {
         self.as_bytes().copy_onto(&mut target.inner)
     }
-
-    fn reserve_items<I>(target: &mut StringRegion, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        CopyOnto::reserve_items(&mut target.inner, items.map(str::as_bytes))
-    }
 }
 
 impl CopyOnto<StringRegion> for &&str {
     #[inline]
     fn copy_onto(self, target: &mut StringRegion) -> <StringRegion as Region>::Index {
         self.as_bytes().copy_onto(&mut target.inner)
-    }
-
-    fn reserve_items<I>(target: &mut StringRegion, items: I)
-    where
-        I: Iterator<Item = Self> + Clone,
-    {
-        CopyOnto::reserve_items(&mut target.inner, items.map(|s| s.as_bytes()))
     }
 }
 

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -63,11 +63,6 @@ macro_rules! tuple_flatcontainer {
                     let ($($name,)*) = self;
                     ($($name.copy_onto(&mut target.[<container $name>]),)*)
                 }
-
-                fn reserve_items<It>(_target: &mut [<Tuple $($name)* Region>]<$([<$name _C>]),*>, _items: It)
-                where
-                    It: Iterator<Item = Self> + Clone {
-                }
             }
 
             #[allow(non_camel_case_types)]
@@ -83,10 +78,6 @@ macro_rules! tuple_flatcontainer {
                     -> <[<Tuple $($name)* Region>]<$([<$name _C>]),*> as Region>::Index {
                     let ($($name,)*) = self;
                     ($($name.copy_onto(&mut target.[<container $name>]),)*)
-                }
-                fn reserve_items<It>(_target: &mut [<Tuple $($name)* Region>]<$([<$name _C>]),*>, _items: It)
-                where
-                    It: Iterator<Item = Self> + Clone {
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,6 @@ pub trait CopyOnto<C: Region> {
     /// Copy self into the target container, returning an index that allows to
     /// look up the corresponding read item.
     fn copy_onto(self, target: &mut C) -> C::Index;
-
-    /// Ensure that the region can absorb `items` without reallocation.
-    fn reserve_items<I>(target: &mut C, items: I)
-    where
-        I: Iterator<Item = Self> + Clone;
 }
 
 pub trait ReserveItems<R: Region> {
@@ -258,13 +253,6 @@ mod tests {
             let hobbies = (&self.hobbies).copy_onto(&mut target.hobbies);
             (name, age, hobbies)
         }
-
-        fn reserve_items<I>(_target: &mut PersonRegion, _items: I)
-        where
-            I: Iterator<Item = Self> + Clone,
-        {
-            todo!()
-        }
     }
 
     impl<'a> ReserveItems<PersonRegion> for &'a Person {
@@ -284,13 +272,6 @@ mod tests {
             let age = self.age.copy_onto(&mut target.age_container);
             let hobbies = self.hobbies.copy_onto(&mut target.hobbies);
             (name, age, hobbies)
-        }
-
-        fn reserve_items<I>(_target: &mut PersonRegion, _items: I)
-        where
-            I: Iterator<Item = Self> + Clone,
-        {
-            todo!()
         }
     }
 


### PR DESCRIPTION
It could only be implemented for a subset of `CopyOnto` implementations, namely those defined on references. The `ReserveItems` trait provides a better alternative.