### PR TITLE
Relax Rust version to 1.65

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update 1.70 --no-self-update && rustup default 1.70
+    - run: rustup update 1.65 --no-self-update && rustup default 1.65
     - run: cargo build --workspace --lib --bins --examples --tests
     - run: cargo test --workspace --lib --bins --examples --tests
     - run: rustup component add rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 description = "A flat container representation for Rust"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/antiguru/flatcontainer"
-rust-version = "1.70"
+rust-version = "1.65"
 
 [dependencies]
 cfg-if = "1.0"


### PR DESCRIPTION
GATs are part of Rust since 1.65, so that's all we need.