### PR TITLE
Remove CopyOnto requirement for ReadItem

### DIFF
--- a/src/impls/codec.rs
+++ b/src/impls/codec.rs
@@ -80,7 +80,6 @@ pub struct CodecRegion<C: Codec, R = CopyRegion<u8>> {
 impl<C: Codec, R> Region for CodecRegion<C, R>
 where
     for<'a> R: Region<ReadItem<'a> = &'a [u8]> + 'a,
-    for<'a> &'a [u8]: CopyOnto<R>,
 {
     type ReadItem<'a> = &'a [u8]
     where

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -238,9 +238,10 @@ where
     }
 }
 
-impl<'a, R> CopyOnto<ColumnsRegion<R>> for ReadColumns<'a, R>
+impl<R> CopyOnto<ColumnsRegion<R>> for ReadColumns<'_, R>
 where
     R: Region,
+    for<'a> R::ReadItem<'a>: CopyOnto<R>,
 {
     fn copy_onto(self, target: &mut ColumnsRegion<R>) -> <ColumnsRegion<R> as Region>::Index {
         // Ensure all required regions exist.

--- a/src/impls/deduplicate.rs
+++ b/src/impls/deduplicate.rs
@@ -36,10 +36,7 @@ impl<R: Region> Default for CollapseSequence<R> {
     }
 }
 
-impl<R: Region> Region for CollapseSequence<R>
-where
-    for<'a, 'b> R::ReadItem<'a>: PartialEq<R::ReadItem<'b>>,
-{
+impl<R: Region> Region for CollapseSequence<R> {
     type ReadItem<'a> = R::ReadItem<'a> where Self: 'a;
     type Index = R::Index;
 
@@ -78,7 +75,6 @@ where
 impl<R: Region, T: CopyOnto<R>> CopyOnto<CollapseSequence<R>> for T
 where
     for<'a> T: PartialEq<R::ReadItem<'a>>,
-    for<'a, 'b> R::ReadItem<'a>: PartialEq<R::ReadItem<'b>>,
 {
     fn copy_onto(self, target: &mut CollapseSequence<R>) -> <CollapseSequence<R> as Region>::Index {
         if let Some(last_index) = target.last_index {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl<T: Copy> Index for T {}
 /// Implement the [`CopyOnto`] trait for all types that can be copied into a region.
 pub trait Region: Default {
     /// The type of the data that one gets out of the container.
-    type ReadItem<'a>: CopyOnto<Self>
+    type ReadItem<'a>
     where
         Self: 'a;
 
@@ -287,7 +287,10 @@ impl<R: Region, T: CopyOnto<R>> FromIterator<T> for FlatStack<R> {
     }
 }
 
-impl<R: Region> Clone for FlatStack<R> {
+impl<R: Region> Clone for FlatStack<R>
+where
+    for<'a> R::ReadItem<'a>: CopyOnto<R>,
+{
     fn clone(&self) -> Self {
         let mut clone = Self::merge_capacity(std::iter::once(self));
         clone.extend(self.iter());
@@ -514,7 +517,7 @@ mod tests {
         where
             T: CopyOnto<R>,
             // Make sure that types are debug, even if we don't use this in the test.
-            for<'a> R::ReadItem<'a>: Debug,
+            for<'a> R::ReadItem<'a>: Debug + CopyOnto<R>,
         {
             let mut c = FlatStack::default();
             c.copy(t);


### PR DESCRIPTION
Remove the requirement that `Region::ReadItem` implements `CopyOnto<Self>` because it infects the region with the type bounds of the specific implementation without adding much value. It still is a good idea that implementations offer this functionality, but it seems overly restrictive to enforce this property for all implementations.

cc @ParkMyCar