### PR TITLE
Add tests and cleanup minor findings

### DIFF
--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -153,3 +153,16 @@ implement_for!(std::num::Wrapping<i128>);
 implement_for!(std::num::Wrapping<isize>);
 
 implement_for!(std::time::Duration);
+
+#[cfg(test)]
+mod tests {
+    use crate::ReserveItems;
+
+    use super::*;
+
+    #[test]
+    fn test_reserve_regions() {
+        let mut r = MirrorRegion::<u8>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::once(0));
+    }
+}

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -102,3 +102,27 @@ where
         ReserveItems::reserve_items(&mut target.inner, items.filter_map(|r| r.as_ref()));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{CopyRegion, MirrorRegion, Region, ReserveItems};
+
+    use super::*;
+
+    #[test]
+    fn test_reserve() {
+        let mut r = <OptionRegion<MirrorRegion<u8>>>::default();
+        ReserveItems::reserve_items(&mut r, [Some(0), None].iter());
+    }
+
+    #[test]
+    fn test_heap_size() {
+        let mut r = <OptionRegion<CopyRegion<u8>>>::default();
+        ReserveItems::reserve_items(&mut r, [Some([1; 1]), None].iter());
+        let mut cap = 0;
+        r.heap_size(|_, ca| {
+            cap += ca;
+        });
+        assert!(cap > 0);
+    }
+}

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -136,3 +136,27 @@ where
         ReserveItems::reserve_items(&mut target.errs, items.filter_map(|r| r.as_ref().err()));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{CopyRegion, MirrorRegion, Region, ReserveItems};
+
+    use super::*;
+
+    #[test]
+    fn test_reserve() {
+        let mut r = <ResultRegion<MirrorRegion<u8>, MirrorRegion<u8>>>::default();
+        ReserveItems::reserve_items(&mut r, [Ok(0), Err(1)].iter());
+    }
+
+    #[test]
+    fn test_heap_size() {
+        let mut r = <ResultRegion<CopyRegion<u8>, CopyRegion<u8>>>::default();
+        ReserveItems::reserve_items(&mut r, [Ok([1; 0]), Err([1; 1])].iter());
+        let mut cap = 0;
+        r.heap_size(|_, ca| {
+            cap += ca;
+        });
+        assert!(cap > 0);
+    }
+}

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -189,3 +189,45 @@ impl<T: Copy, J: IntoIterator<Item = T>> ReserveItems<CopyRegion<T>> for CopyIte
             .reserve(items.flat_map(|i| i.0.into_iter()).count());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{CopyIter, CopyOnto, Region, ReserveItems};
+
+    use super::*;
+
+    #[test]
+    fn test_copy_array() {
+        let mut r = <CopyRegion<u8>>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::once(&[1; 4]));
+        let index = [1; 4].copy_onto(&mut r);
+        assert_eq!([1, 1, 1, 1], r.index(index));
+    }
+
+    #[test]
+    fn test_copy_ref_ref_array() {
+        let mut r = <CopyRegion<u8>>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::once(&[1; 4]));
+        let index = (&&[1; 4]).copy_onto(&mut r);
+        assert_eq!([1, 1, 1, 1], r.index(index));
+    }
+
+    #[test]
+    fn test_copy_vec() {
+        let mut r = <CopyRegion<u8>>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::once(&vec![1; 4]));
+        let index = (&vec![1; 4]).copy_onto(&mut r);
+        assert_eq!([1, 1, 1, 1], r.index(index));
+    }
+
+    #[test]
+    fn test_copy_iter() {
+        let mut r = <CopyRegion<u8>>::default();
+        ReserveItems::reserve_items(
+            &mut r,
+            std::iter::once(CopyIter(std::iter::repeat(1).take(4))),
+        );
+        let index = CopyIter(std::iter::repeat(1).take(4)).copy_onto(&mut r);
+        assert_eq!([1, 1, 1, 1], r.index(index));
+    }
+}

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -170,12 +170,57 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{CopyOnto, Region, StringRegion};
+    use crate::{CopyOnto, Region, ReserveItems, StringRegion};
 
     #[test]
     fn test_inner() {
         let mut r = <StringRegion>::default();
         let index = "abc".copy_onto(&mut r);
         assert_eq!(r.index(index), "abc");
+    }
+
+    #[test]
+    fn test_reserve_items_str() {
+        let mut r = <StringRegion>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::repeat("abc").take(1000));
+
+        let (mut cap, mut cnt) = (0, 0);
+        r.heap_size(|_, c| {
+            cap += c;
+            cnt += 1;
+        });
+
+        assert!(cap > 0);
+        assert!(cnt > 0);
+    }
+
+    #[test]
+    fn test_reserve_items_ref_str() {
+        let mut r = <StringRegion>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::repeat(&"abc").take(1000));
+
+        let (mut cap, mut cnt) = (0, 0);
+        r.heap_size(|_, c| {
+            cap += c;
+            cnt += 1;
+        });
+
+        assert!(cap > 0);
+        assert!(cnt > 0);
+    }
+
+    #[test]
+    fn test_reserve_items_string() {
+        let mut r = <StringRegion>::default();
+        ReserveItems::reserve_items(&mut r, std::iter::repeat(&"abc".to_owned()).take(1000));
+
+        let (mut cap, mut cnt) = (0, 0);
+        r.heap_size(|_, c| {
+            cap += c;
+            cnt += 1;
+        });
+
+        assert!(cap > 0);
+        assert!(cnt > 0);
     }
 }

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -200,4 +200,25 @@ mod tests {
         let index = (&("abc", 2, 3)).copy_onto(&mut r);
         assert_eq!(t, r.index(index));
     }
+
+    #[test]
+    fn test_heap_size() {
+        let t = ("abc", 2, 3);
+        let mut r = <TupleABCRegion<StringRegion, MirrorRegion<_>, MirrorRegion<_>>>::default();
+
+        let _ = t.copy_onto(&mut r);
+
+        let (mut size, mut cap, mut cnt) = (0, 0, 0);
+        r.heap_size(|siz, ca| {
+            size += siz;
+            cap += ca;
+            cnt += 1;
+        });
+
+        println!("size {size} cap {cap} cnt {cnt}");
+
+        assert!(size > 0);
+        assert!(cap > 0);
+        assert!(cnt > 0);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,7 @@ impl<R: Region> Clone for FlatStack<R> {
 /// This only exists to avoid blanket implementations that might conflict with more specific
 /// implementations offered by some regions.
 #[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct CopyIter<I>(pub I);
 
 #[cfg(test)]
@@ -520,6 +521,16 @@ mod tests {
 
             let mut cc = c.clone();
             cc.copy(c.get(0));
+
+            c.clear();
+
+            let mut r = R::default();
+            cc.get(0).copy_onto(&mut r);
+
+            c.reserve_regions(std::iter::once(&r));
+
+            let mut c = FlatStack::merge_capacity(std::iter::once(&c));
+            c.copy(cc.get(0));
         }
 
         test_copy::<_, StringRegion>(&"a".to_string());
@@ -575,6 +586,8 @@ mod tests {
 
         test_copy::<_, ResultRegion<MirrorRegion<u8>, MirrorRegion<u8>>>(Result::<u8, u8>::Ok(0));
         test_copy::<_, ResultRegion<MirrorRegion<u8>, MirrorRegion<u8>>>(&Result::<u8, u8>::Ok(0));
+        test_copy::<_, ResultRegion<MirrorRegion<u8>, MirrorRegion<u8>>>(Result::<u8, u8>::Err(0));
+        test_copy::<_, ResultRegion<MirrorRegion<u8>, MirrorRegion<u8>>>(&Result::<u8, u8>::Err(0));
 
         test_copy::<_, SliceRegion<MirrorRegion<u8>>>([0u8].as_slice());
         test_copy::<_, SliceRegion<MirrorRegion<u8>>>(vec![0u8]);


### PR DESCRIPTION
Add tests to increase coverage. This surfaced a few defects, namely that `CopyIter` didn't implement useful traits (copy, clone, etc.), and removes the `Idx` parameter of `ColumnsRegion`. It was implied by the inner region.