### PR TITLE
Slice regions support nested slices and references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,4 +648,25 @@ mod tests {
         let _read_item3 = read_item;
         assert_eq!(vec![1, 2, 3], read_item.into_iter().collect::<Vec<_>>());
     }
+
+    #[test]
+    fn nested_slice_copy() {
+        let mut c = FlatStack::default_impl::<[[[[[u8; 1]; 1]; 1]; 1]; 1]>();
+
+        c.copy([[[[[1]]]]]);
+        c.copy(&[[[[[1]]]]]);
+        c.copy(&[[[[[&1]]]]]);
+        c.copy([[[[[&1]]]]]);
+        c.copy([[&[[[&1]]]]]);
+        c.copy([[[[[1]]; 1]; 1]; 1]);
+        c.copy(&[[[[[1; 1]; 1]; 1]; 1]; 1]);
+        c.copy(&[[[[[&1; 1]; 1]; 1]; 1]; 1]);
+        c.copy([[[[[&1; 1]; 1]; 1]; 1]; 1]);
+        c.copy([[&[[[&1; 1]; 1]; 1]; 1]; 1]);
+        c.copy([[vec![[[1; 1]; 1]; 1]; 1]; 1]);
+        c.copy(&[[vec![[[1; 1]; 1]; 1]; 1]; 1]);
+        c.copy(&[[vec![[[&1; 1]; 1]; 1]; 1]; 1]);
+        c.copy([[[vec![[&1; 1]; 1]; 1]; 1]; 1]);
+        c.copy([[&vec![[[&1; 1]; 1]; 1]; 1]; 1]);
+    }
 }


### PR DESCRIPTION
This changes the slice region to support copy-onto for && types, which is needed to support arbitrarily nested slices and things that look like slices. Probably want to establish a rule that copy-onto should be implemented for owned types, references and references to references.