### PR TITLE
Rename CopyRegion to OwnedRegion and relax trait bounds

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,7 @@ use flatcontainer::impls::deduplicate::{CollapseSequence, ConsecutiveOffsetPairs
 use flatcontainer::impls::offsets::OffsetOptimized;
 use flatcontainer::impls::tuple::{TupleABCRegion, TupleABRegion};
 use flatcontainer::{
-    ColumnsRegion, Containerized, CopyOnto, CopyRegion, FlatStack, MirrorRegion, Region,
+    ColumnsRegion, Containerized, CopyOnto, FlatStack, MirrorRegion, OwnedRegion, Region,
     ReserveItems, SliceRegion, StringRegion,
 };
 use test::Bencher;
@@ -58,27 +58,27 @@ fn vec_u_vn_s_copy(bencher: &mut Bencher) {
 
 #[bench]
 fn empty_copy_region(bencher: &mut Bencher) {
-    _bench_copy_region::<CopyRegion<_>, _>(bencher, vec![(); 1024]);
+    _bench_copy_region::<OwnedRegion<_>, _>(bencher, vec![(); 1024]);
 }
 #[bench]
 fn u64_copy_region(bencher: &mut Bencher) {
-    _bench_copy_region::<CopyRegion<_>, _>(bencher, vec![0u64; 1024]);
+    _bench_copy_region::<OwnedRegion<_>, _>(bencher, vec![0u64; 1024]);
 }
 #[bench]
 fn u32x2_copy_region(bencher: &mut Bencher) {
-    _bench_copy_region::<CopyRegion<_>, _>(bencher, vec![(0u32, 0u32); 1024]);
+    _bench_copy_region::<OwnedRegion<_>, _>(bencher, vec![(0u32, 0u32); 1024]);
 }
 #[bench]
 fn u8_u64_copy_region(bencher: &mut Bencher) {
-    _bench_copy_region::<CopyRegion<_>, _>(bencher, vec![(0u8, 0u64); 512]);
+    _bench_copy_region::<OwnedRegion<_>, _>(bencher, vec![(0u8, 0u64); 512]);
 }
 #[bench]
 fn str10_copy_region(bencher: &mut Bencher) {
-    _bench_copy_region::<CopyRegion<_>, _>(bencher, vec!["grawwwwrr!"; 1024]);
+    _bench_copy_region::<OwnedRegion<_>, _>(bencher, vec!["grawwwwrr!"; 1024]);
 }
 #[bench]
 fn str100_copy_region(bencher: &mut Bencher) {
-    _bench_copy_region::<CopyRegion<_>, _>(bencher, vec!["grawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrr!!!!!!!!!grawwwwrr!"; 1024]);
+    _bench_copy_region::<OwnedRegion<_>, _>(bencher, vec!["grawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrr!!!!!!!!!grawwwwrr!"; 1024]);
 }
 #[bench]
 fn string10_copy_region(bencher: &mut Bencher) {
@@ -108,7 +108,7 @@ fn vec_u_s_copy_region(bencher: &mut Bencher) {
 #[bench]
 fn vec_u_vn_s_copy_region(bencher: &mut Bencher) {
     _bench_copy_region::<
-        SliceRegion<SliceRegion<TupleABCRegion<MirrorRegion<_>, CopyRegion<_>, StringRegion>>>,
+        SliceRegion<SliceRegion<TupleABCRegion<MirrorRegion<_>, OwnedRegion<_>, StringRegion>>>,
         _,
     >(
         bencher,
@@ -122,7 +122,7 @@ fn vec_u_vn_s_copy_region_column(bencher: &mut Bencher) {
             ColumnsRegion<
                 TupleABCRegion<
                     MirrorRegion<_>,
-                    CollapseSequence<CopyRegion<_>>,
+                    CollapseSequence<OwnedRegion<_>>,
                     CollapseSequence<StringRegion>,
                 >,
                 _,

--- a/src/impls/codec.rs
+++ b/src/impls/codec.rs
@@ -1,6 +1,6 @@
 //! A region that encodes its contents.
 
-use crate::{CopyOnto, CopyRegion, Region};
+use crate::{CopyOnto, OwnedRegion, Region};
 
 pub use self::misra_gries::MisraGries;
 pub use dictionary::DictionaryCodec;
@@ -72,7 +72,7 @@ fn consolidate_slice<T: Ord>(slice: &mut [(T, usize)]) -> usize {
 
 /// A region that encodes its data in a codec `C`.
 #[derive(Default, Debug)]
-pub struct CodecRegion<C: Codec, R = CopyRegion<u8>> {
+pub struct CodecRegion<C: Codec, R = OwnedRegion<u8>> {
     inner: R,
     codec: C,
 }

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::impls::deduplicate::ConsecutiveOffsetPairs;
 use crate::impls::offsets::OffsetOptimized;
 use crate::CopyIter;
-use crate::{CopyOnto, CopyRegion, Region};
+use crate::{CopyOnto, OwnedRegion, Region};
 
 /// A region that can store a variable number of elements per row.
 ///
@@ -62,7 +62,7 @@ where
 {
     /// Indices to address rows in `inner`. For each row, we remember
     /// an index for each column.
-    indices: ConsecutiveOffsetPairs<CopyRegion<R::Index>, OffsetOptimized>,
+    indices: ConsecutiveOffsetPairs<OwnedRegion<R::Index>, OffsetOptimized>,
     /// Storage for columns.
     inner: Vec<R>,
 }
@@ -374,7 +374,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::impls::deduplicate::{CollapseSequence, ConsecutiveOffsetPairs};
-    use crate::{CopyIter, CopyOnto, CopyRegion, MirrorRegion, Region, StringRegion};
+    use crate::{CopyIter, CopyOnto, MirrorRegion, OwnedRegion, Region, StringRegion};
 
     use super::*;
 
@@ -518,8 +518,8 @@ mod tests {
     fn read_columns_copy_onto() {
         let data = [[[1]; 4]; 4];
 
-        let mut r = <ColumnsRegion<CopyRegion<u8>>>::default();
-        let mut r2 = <ColumnsRegion<CopyRegion<u8>>>::default();
+        let mut r = <ColumnsRegion<OwnedRegion<u8>>>::default();
+        let mut r2 = <ColumnsRegion<OwnedRegion<u8>>>::default();
 
         for row in &data {
             let idx = row.copy_onto(&mut r);
@@ -533,7 +533,7 @@ mod tests {
     fn test_clear() {
         let data = [[[1]; 4]; 4];
 
-        let mut r = <ColumnsRegion<CopyRegion<u8>>>::default();
+        let mut r = <ColumnsRegion<OwnedRegion<u8>>>::default();
 
         let mut idx = None;
         for row in &data {
@@ -548,7 +548,7 @@ mod tests {
     fn copy_reserve_regions() {
         let data = [[[1]; 4]; 4];
 
-        let mut r = <ColumnsRegion<CopyRegion<u8>>>::default();
+        let mut r = <ColumnsRegion<OwnedRegion<u8>>>::default();
 
         for row in &data {
             row.copy_onto(&mut r);
@@ -557,7 +557,7 @@ mod tests {
             row.copy_onto(&mut r);
         }
 
-        let mut r2 = <ColumnsRegion<CopyRegion<u8>>>::default();
+        let mut r2 = <ColumnsRegion<OwnedRegion<u8>>>::default();
         r2.reserve_regions(std::iter::once(&r));
 
         let mut cap = 0;

--- a/src/impls/deduplicate.rs
+++ b/src/impls/deduplicate.rs
@@ -99,8 +99,8 @@ where
 /// The following example shows that two inserts into a copy region have a collapsible index:
 /// ```
 /// use flatcontainer::impls::deduplicate::{CollapseSequence, ConsecutiveOffsetPairs};
-/// use flatcontainer::{CopyOnto, CopyRegion, Region, StringRegion};
-/// let mut r = <ConsecutiveOffsetPairs<CopyRegion<u8>>>::default();
+/// use flatcontainer::{CopyOnto, OwnedRegion, Region, StringRegion};
+/// let mut r = <ConsecutiveOffsetPairs<OwnedRegion<u8>>>::default();
 ///
 /// let index: usize = b"abc"[..].copy_onto(&mut r);
 /// assert_eq!(b"abc", r.index(index));

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -105,7 +105,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{CopyRegion, MirrorRegion, Region, ReserveItems};
+    use crate::{MirrorRegion, OwnedRegion, Region, ReserveItems};
 
     use super::*;
 
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_heap_size() {
-        let mut r = <OptionRegion<CopyRegion<u8>>>::default();
+        let mut r = <OptionRegion<OwnedRegion<u8>>>::default();
         ReserveItems::reserve_items(&mut r, [Some([1; 1]), None].iter());
         let mut cap = 0;
         r.heap_size(|_, ca| {

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -139,7 +139,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{CopyRegion, MirrorRegion, Region, ReserveItems};
+    use crate::{MirrorRegion, OwnedRegion, Region, ReserveItems};
 
     use super::*;
 
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_heap_size() {
-        let mut r = <ResultRegion<CopyRegion<u8>, CopyRegion<u8>>>::default();
+        let mut r = <ResultRegion<OwnedRegion<u8>, OwnedRegion<u8>>>::default();
         ReserveItems::reserve_items(&mut r, [Ok([1; 0]), Err([1; 1])].iter());
         let mut cap = 0;
         r.heap_size(|_, ca| {

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -3,12 +3,12 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::impls::slice_copy::CopyRegion;
+use crate::impls::slice_copy::OwnedRegion;
 use crate::{Containerized, CopyOnto, Region, ReserveItems};
 
 /// A region to store strings and read `&str`.
 ///
-/// Delegates to a region `R` to store `u8` slices. By default, it uses a [`CopyRegion`], but a
+/// Delegates to a region `R` to store `u8` slices. By default, it uses a [`OwnedRegion`], but a
 /// different region can be provided, as long as it absorbs and reads items as `&[u8]`.
 ///
 /// Note that all implementations of `CopyOnto<StringRegion>` must only accept valid utf-8 data
@@ -18,7 +18,7 @@ use crate::{Containerized, CopyOnto, Region, ReserveItems};
 ///
 /// We fill some data into a string region and use extract it later.
 /// ```
-/// use flatcontainer::{Containerized, CopyOnto, CopyRegion, Region, StringRegion};
+/// use flatcontainer::{Containerized, CopyOnto, OwnedRegion, Region, StringRegion};
 /// let mut r = <StringRegion>::default();
 ///
 /// let panagram_en = "The quick fox jumps over the lazy dog";
@@ -32,7 +32,7 @@ use crate::{Containerized, CopyOnto, Region, ReserveItems};
 /// ```
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct StringRegion<R = CopyRegion<u8>>
+pub struct StringRegion<R = OwnedRegion<u8>>
 where
     for<'a> R: Region<ReadItem<'a> = &'a [u8]> + 'a,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use impls::mirror::MirrorRegion;
 pub use impls::option::OptionRegion;
 pub use impls::result::ResultRegion;
 pub use impls::slice::SliceRegion;
-pub use impls::slice_copy::CopyRegion;
+pub use impls::slice_copy::OwnedRegion;
 pub use impls::string::StringRegion;
 
 /// An index into a region. Automatically implemented for relevant types.
@@ -604,16 +604,16 @@ mod tests {
         test_copy::<_, SliceRegion<TupleARegion<StringRegion>>>(vec![("a",)]);
         test_copy::<_, SliceRegion<TupleARegion<StringRegion>>>(&vec![("a",)]);
 
-        test_copy::<_, CopyRegion<_>>([0u8].as_slice());
-        test_copy::<_, CopyRegion<_>>(&[0u8].as_slice());
+        test_copy::<_, OwnedRegion<_>>([0u8].as_slice());
+        test_copy::<_, OwnedRegion<_>>(&[0u8].as_slice());
 
         test_copy::<_, <(u8, u8) as Containerized>::Region>((1, 2));
         test_copy::<_, <(u8, u8) as Containerized>::Region>(&(1, 2));
 
-        test_copy::<_, ConsecutiveOffsetPairs<CopyRegion<_>>>([1, 2, 3].as_slice());
+        test_copy::<_, ConsecutiveOffsetPairs<OwnedRegion<_>>>([1, 2, 3].as_slice());
 
-        test_copy::<_, CollapseSequence<CopyRegion<_>>>([1, 2, 3].as_slice());
-        test_copy::<_, CollapseSequence<CopyRegion<_>>>(&[1, 2, 3]);
+        test_copy::<_, CollapseSequence<OwnedRegion<_>>>([1, 2, 3].as_slice());
+        test_copy::<_, CollapseSequence<OwnedRegion<_>>>(&[1, 2, 3]);
 
         test_copy::<_, OptionRegion<StringRegion>>(Some("abc"));
         test_copy::<_, OptionRegion<StringRegion>>(&Some("abc"));


### PR DESCRIPTION
This supports arbitrary data in OwnedRegions, only specific copy-onto implementations require clone.