### PR TITLE
Update recommended version to 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A flat container for Rust.
 
 ```toml
 [dependencies]
-flatcontainer = "0.1"
+flatcontainer = "0.3"
 ```
 
 ## Example


### PR DESCRIPTION
Update the recommended version of flatcontainer to 0.3 instead of 0.1.
