### PR TITLE
Thinking about relating owned types and read items

### DIFF
--- a/src/impls/codec.rs
+++ b/src/impls/codec.rs
@@ -72,6 +72,7 @@ impl<C: Codec, R> Region for CodecRegion<C, R>
 where
     for<'a> R: Region<ReadItem<'a> = &'a [u8]> + 'a,
 {
+    type Owned = Vec<u8>;
     type ReadItem<'a> = &'a [u8]
     where
         Self: 'a;

--- a/src/impls/codec.rs
+++ b/src/impls/codec.rs
@@ -422,8 +422,8 @@ mod tests {
         }
         for _ in 0..1000 {
             for r in &mut regions {
-                r.push("abcdef".as_bytes());
-                r.push("defghi".as_bytes());
+                let _ = r.push("abcdef".as_bytes());
+                let _ = r.push("defghi".as_bytes());
             }
         }
 
@@ -448,8 +448,8 @@ mod tests {
         }
         for _ in 0..1000 {
             for r in &mut regions {
-                r.push("abcdef".as_bytes());
-                r.push("defghi".as_bytes());
+                let _ = r.push("abcdef".as_bytes());
+                let _ = r.push("defghi".as_bytes());
             }
         }
 

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -267,16 +267,18 @@ where
 {
     type Owned = Vec<R::Owned>;
 
-    fn into_owned(self) -> Self::Owned {
-        self.iter().map(IntoOwned::into_owned).collect()
+    fn into_owned(&self) -> Self::Owned {
+        self.iter()
+            .map(|item| IntoOwned::into_owned(&item))
+            .collect()
     }
 
-    fn clone_onto(self, other: &mut Self::Owned) {
+    fn clone_onto(&self, other: &mut Self::Owned) {
         let r = std::cmp::min(self.len(), other.len());
         for (item, target) in self.iter().zip(other.iter_mut()) {
             item.clone_onto(target);
         }
-        other.extend(self.iter().skip(r).map(IntoOwned::into_owned));
+        other.extend(self.iter().skip(r).map(|item| IntoOwned::into_owned(&item)));
         other.truncate(self.len());
     }
 

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -267,6 +267,7 @@ where
 {
     type Owned = Vec<R::Owned>;
 
+    #[inline]
     fn into_owned(self) -> Self::Owned {
         self.iter().map(IntoOwned::into_owned).collect()
     }
@@ -633,7 +634,7 @@ mod tests {
         }
 
         r.clear();
-        r.index(idx.unwrap());
+        let _ = r.index(idx.unwrap());
     }
 
     #[test]
@@ -643,10 +644,10 @@ mod tests {
         let mut r = <ColumnsRegion<OwnedRegion<u8>>>::default();
 
         for row in &data {
-            r.push(row);
+            let _ = r.push(row);
         }
         for row in data {
-            r.push(row);
+            let _ = r.push(row);
         }
 
         let mut r2 = <ColumnsRegion<OwnedRegion<u8>>>::default();

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -226,7 +226,7 @@ where
         self.iter().map(IntoOwned::into_owned).collect()
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         todo!()
     }
 

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -267,18 +267,16 @@ where
 {
     type Owned = Vec<R::Owned>;
 
-    fn into_owned(&self) -> Self::Owned {
-        self.iter()
-            .map(|item| IntoOwned::into_owned(&item))
-            .collect()
+    fn into_owned(self) -> Self::Owned {
+        self.iter().map(IntoOwned::into_owned).collect()
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         let r = std::cmp::min(self.len(), other.len());
         for (item, target) in self.iter().zip(other.iter_mut()) {
             item.clone_onto(target);
         }
-        other.extend(self.iter().skip(r).map(|item| IntoOwned::into_owned(&item)));
+        other.extend(self.iter().skip(r).map(IntoOwned::into_owned));
         other.truncate(self.len());
     }
 

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -277,6 +277,7 @@ where
             item.clone_onto(target);
         }
         other.extend(self.iter().skip(r).map(IntoOwned::into_owned));
+        other.truncate(self.len());
     }
 
     fn borrow_as(owned: &'a Self::Owned) -> Self {

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::impls::deduplicate::ConsecutiveOffsetPairs;
 use crate::impls::offsets::OffsetOptimized;
-use crate::CopyIter;
+use crate::{CopyIter, IntoOwned};
 use crate::{OwnedRegion, Push, Region};
 
 /// A region that can store a variable number of elements per row.
@@ -71,6 +71,7 @@ impl<R> Region for ColumnsRegion<R>
 where
     R: Region,
 {
+    type Owned = Vec<R::Owned>;
     type ReadItem<'a> = ReadColumns<'a, R> where Self: 'a;
     type Index = usize;
 
@@ -212,6 +213,25 @@ where
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.index.is_empty()
+    }
+}
+
+impl<'a, R> IntoOwned<'a> for ReadColumns<'a, R>
+where
+    R: Region,
+{
+    type Owned = Vec<R::Owned>;
+
+    fn into_owned(self) -> Self::Owned {
+        self.iter().map(IntoOwned::into_owned).collect()
+    }
+
+    fn clone_onto(&self, other: &mut Self::Owned) {
+        todo!()
+    }
+
+    fn borrow_as(owned: &'a Self::Owned) -> Self {
+        todo!()
     }
 }
 

--- a/src/impls/deduplicate.rs
+++ b/src/impls/deduplicate.rs
@@ -37,6 +37,7 @@ impl<R: Region> Default for CollapseSequence<R> {
 }
 
 impl<R: Region> Region for CollapseSequence<R> {
+    type Owned = R::Owned;
     type ReadItem<'a> = R::ReadItem<'a> where Self: 'a;
     type Index = R::Index;
 
@@ -147,6 +148,7 @@ where
     R: Region<Index = (usize, usize)>,
     O: OffsetContainer<usize>,
 {
+    type Owned = R::Owned;
     type ReadItem<'a> = R::ReadItem<'a>
     where
         Self: 'a;

--- a/src/impls/deduplicate.rs
+++ b/src/impls/deduplicate.rs
@@ -132,6 +132,7 @@ where
 impl<R: Region<Index = (usize, usize)>, O: OffsetContainer<usize>> Default
     for ConsecutiveOffsetPairs<R, O>
 {
+    #[inline]
     fn default() -> Self {
         let mut d = Self {
             inner: Default::default(),
@@ -155,6 +156,7 @@ where
 
     type Index = usize;
 
+    #[inline]
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -168,11 +170,13 @@ where
         }
     }
 
+    #[inline]
     fn index(&self, index: Self::Index) -> Self::ReadItem<'_> {
         self.inner
             .index((self.offsets.index(index), self.offsets.index(index + 1)))
     }
 
+    #[inline]
     fn reserve_regions<'a, I>(&mut self, regions: I)
     where
         Self: 'a,
@@ -181,6 +185,7 @@ where
         self.inner.reserve_regions(regions.map(|r| &r.inner));
     }
 
+    #[inline]
     fn clear(&mut self) {
         self.last_index = 0;
         self.inner.clear();
@@ -188,11 +193,13 @@ where
         self.offsets.push(0);
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, mut callback: F) {
         self.offsets.heap_size(&mut callback);
         self.inner.heap_size(callback);
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -249,7 +256,7 @@ mod tests {
             CollapseSequence::<ConsecutiveOffsetPairs<StringRegion, OffsetOptimized>>::default();
 
         for _ in 0..1000 {
-            r.push("abc");
+            let _ = r.push("abc");
         }
 
         println!("{r:?}");

--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -151,12 +151,12 @@ macro_rules! implement_for {
         impl<'a> IntoOwned<'a> for $index_type {
             type Owned = $index_type;
 
-            fn into_owned(&self) -> Self::Owned {
-                *self
+            fn into_owned(self) -> Self::Owned {
+                self
             }
 
-            fn clone_onto(&self, other: &mut Self::Owned) {
-                *other = *self;
+            fn clone_onto(self, other: &mut Self::Owned) {
+                *other = self;
             }
 
             fn borrow_as(owned: &'a Self::Owned) -> Self {

--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -151,12 +151,12 @@ macro_rules! implement_for {
         impl<'a> IntoOwned<'a> for $index_type {
             type Owned = $index_type;
 
-            fn into_owned(self) -> Self::Owned {
-                self
+            fn into_owned(&self) -> Self::Owned {
+                *self
             }
 
-            fn clone_onto(self, other: &mut Self::Owned) {
-                *other = self;
+            fn clone_onto(&self, other: &mut Self::Owned) {
+                *other = *self;
             }
 
             fn borrow_as(owned: &'a Self::Owned) -> Self {

--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -155,8 +155,8 @@ macro_rules! implement_for {
                 self
             }
 
-            fn clone_onto(&self, other: &mut Self::Owned) {
-                *other = *self;
+            fn clone_onto(self, other: &mut Self::Owned) {
+                *other = self;
             }
 
             fn borrow_as(owned: &'a Self::Owned) -> Self {

--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -48,6 +48,7 @@ where
     type ReadItem<'a> = T where T: 'a;
     type Index = T;
 
+    #[inline]
     fn merge_regions<'a>(_regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -74,10 +75,12 @@ where
         // No storage
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, _callback: F) {
         // No storage
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -151,14 +154,17 @@ macro_rules! implement_for {
         impl<'a> IntoOwned<'a> for $index_type {
             type Owned = $index_type;
 
+            #[inline]
             fn into_owned(self) -> Self::Owned {
                 self
             }
 
+            #[inline]
             fn clone_onto(self, other: &mut Self::Owned) {
                 *other = self;
             }
 
+            #[inline]
             fn borrow_as(owned: &'a Self::Owned) -> Self {
                 *owned
             }

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{Containerized, IntoOwned, OpinionatedRegion, Push, Region, ReserveItems};
+use crate::{Containerized, IntoOwned, Push, Region, ReserveItems};
 
 impl<T: Containerized> Containerized for Option<T> {
     type Region = OptionRegion<T::Region>;
@@ -73,20 +73,6 @@ impl<R: Region> Region for OptionRegion<R> {
         Self: 'a,
     {
         item.map(R::reborrow)
-    }
-}
-
-impl<R: OpinionatedRegion> OpinionatedRegion for OptionRegion<R> {
-    fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
-        item.map(R::item_to_owned)
-    }
-
-    fn item_to_owned_into(item: Self::ReadItem<'_>, target: &mut Self::Owned) {
-        match (item, target) {
-            (Some(item), Some(target)) => R::item_to_owned_into(item, target),
-            (Some(item), target) => *target = Some(R::item_to_owned(item)),
-            (None, target) => *target = None,
-        }
     }
 }
 

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -91,7 +91,9 @@ impl<R: OpinionatedRegion> OpinionatedRegion for OptionRegion<R> {
 }
 
 impl<'a, T> IntoOwned<'a> for Option<T>
-where T: IntoOwned<'a> {
+where
+    T: IntoOwned<'a>,
+{
     type Owned = Option<T::Owned>;
 
     fn into_owned(self) -> Self::Owned {

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -98,12 +98,16 @@ where T: IntoOwned<'a> {
         self.map(IntoOwned::into_owned)
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
-        todo!()
+    fn clone_onto(self, other: &mut Self::Owned) {
+        match (self, other) {
+            (Some(item), Some(target)) => T::clone_onto(item, target),
+            (Some(item), target) => *target = Some(T::into_owned(item)),
+            (None, target) => *target = None,
+        }
     }
 
     fn borrow_as(owned: &'a Self::Owned) -> Self {
-        todo!()
+        owned.as_ref().map(T::borrow_as)
     }
 }
 

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -82,11 +82,11 @@ where
 {
     type Owned = Option<T::Owned>;
 
-    fn into_owned(&self) -> Self::Owned {
-        self.as_ref().map(IntoOwned::into_owned)
+    fn into_owned(self) -> Self::Owned {
+        self.map(IntoOwned::into_owned)
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         match (self, other) {
             (Some(item), Some(target)) => T::clone_onto(item, target),
             (Some(item), target) => *target = Some(T::into_owned(item)),

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -82,11 +82,11 @@ where
 {
     type Owned = Option<T::Owned>;
 
-    fn into_owned(self) -> Self::Owned {
-        self.map(IntoOwned::into_owned)
+    fn into_owned(&self) -> Self::Owned {
+        self.as_ref().map(IntoOwned::into_owned)
     }
 
-    fn clone_onto(self, other: &mut Self::Owned) {
+    fn clone_onto(&self, other: &mut Self::Owned) {
         match (self, other) {
             (Some(item), Some(target)) => T::clone_onto(item, target),
             (Some(item), target) => *target = Some(T::into_owned(item)),

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -36,6 +36,7 @@ impl<R: Region> Region for OptionRegion<R> {
     type ReadItem<'a> = Option<<R as Region>::ReadItem<'a>> where Self: 'a;
     type Index = Option<R::Index>;
 
+    #[inline]
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -64,10 +65,12 @@ impl<R: Region> Region for OptionRegion<R> {
         self.inner.clear();
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, callback: F) {
         self.inner.heap_size(callback);
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -82,10 +85,12 @@ where
 {
     type Owned = Option<T::Owned>;
 
+    #[inline]
     fn into_owned(self) -> Self::Owned {
         self.map(IntoOwned::into_owned)
     }
 
+    #[inline]
     fn clone_onto(self, other: &mut Self::Owned) {
         match (self, other) {
             (Some(item), Some(target)) => T::clone_onto(item, target),
@@ -94,6 +99,7 @@ where
         }
     }
 
+    #[inline]
     fn borrow_as(owned: &'a Self::Owned) -> Self {
         owned.as_ref().map(T::borrow_as)
     }
@@ -123,6 +129,7 @@ impl<'a, T: 'a, TR> ReserveItems<&'a Option<T>> for OptionRegion<TR>
 where
     TR: Region + ReserveItems<&'a T>,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a Option<T>> + Clone,

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -95,11 +95,11 @@ where
 {
     type Owned = Result<T::Owned, E::Owned>;
 
-    fn into_owned(self) -> Self::Owned {
-        self.map(T::into_owned).map_err(E::into_owned)
+    fn into_owned(&self) -> Self::Owned {
+        self.as_ref().map(T::into_owned).map_err(E::into_owned)
     }
 
-    fn clone_onto(self, other: &mut Self::Owned) {
+    fn clone_onto(&self, other: &mut Self::Owned) {
         match (self, other) {
             (Ok(item), Ok(target)) => T::clone_onto(item, target),
             (Err(item), Err(target)) => E::clone_onto(item, target),

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -99,7 +99,7 @@ where
         self.map(T::into_owned).map_err(E::into_owned)
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         match (self, other) {
             (Ok(item), Ok(target)) => T::clone_onto(item, target),
             (Err(item), Err(target)) => E::clone_onto(item, target),
@@ -109,7 +109,7 @@ where
     }
 
     fn borrow_as(owned: &'a Self::Owned) -> Self {
-        owned.map(T::borrow_as).map_err(E::borrow_as)
+        owned.as_ref().map(T::borrow_as).map_err(E::borrow_as)
     }
 }
 

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -41,6 +41,7 @@ where
     type ReadItem<'a> = Result<T::ReadItem<'a>, E::ReadItem<'a>> where Self: 'a;
     type Index = Result<T::Index, E::Index>;
 
+    #[inline]
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -75,11 +76,13 @@ where
         self.errs.clear();
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, mut callback: F) {
         self.oks.heap_size(&mut callback);
         self.errs.heap_size(callback);
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -95,10 +98,12 @@ where
 {
     type Owned = Result<T::Owned, E::Owned>;
 
+    #[inline]
     fn into_owned(self) -> Self::Owned {
         self.map(T::into_owned).map_err(E::into_owned)
     }
 
+    #[inline]
     fn clone_onto(self, other: &mut Self::Owned) {
         match (self, other) {
             (Ok(item), Ok(target)) => T::clone_onto(item, target),
@@ -108,6 +113,7 @@ where
         }
     }
 
+    #[inline]
     fn borrow_as(owned: &'a Self::Owned) -> Self {
         owned.as_ref().map(T::borrow_as).map_err(E::borrow_as)
     }
@@ -146,6 +152,7 @@ where
     TC: Region + ReserveItems<&'a T>,
     EC: Region + ReserveItems<&'a E>,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a Result<T, E>> + Clone,

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{Containerized, IntoOwned, OpinionatedRegion, Push, Region, ReserveItems};
+use crate::{Containerized, IntoOwned, Push, Region, ReserveItems};
 
 impl<T: Containerized, E: Containerized> Containerized for Result<T, E> {
     type Region = ResultRegion<T::Region, E::Region>;
@@ -110,25 +110,6 @@ where
 
     fn borrow_as(owned: &'a Self::Owned) -> Self {
         owned.as_ref().map(T::borrow_as).map_err(E::borrow_as)
-    }
-}
-
-impl<T, E> OpinionatedRegion for ResultRegion<T, E>
-where
-    T: OpinionatedRegion,
-    E: OpinionatedRegion,
-{
-    fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
-        item.map(T::item_to_owned).map_err(E::item_to_owned)
-    }
-
-    fn item_to_owned_into(item: Self::ReadItem<'_>, target: &mut Self::Owned) {
-        match (item, target) {
-            (Ok(item), Ok(target)) => T::item_to_owned_into(item, target),
-            (Err(item), Err(target)) => E::item_to_owned_into(item, target),
-            (Ok(item), target) => *target = Ok(T::item_to_owned(item)),
-            (Err(item), target) => *target = Err(E::item_to_owned(item)),
-        }
     }
 }
 

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -95,11 +95,11 @@ where
 {
     type Owned = Result<T::Owned, E::Owned>;
 
-    fn into_owned(&self) -> Self::Owned {
-        self.as_ref().map(T::into_owned).map_err(E::into_owned)
+    fn into_owned(self) -> Self::Owned {
+        self.map(T::into_owned).map_err(E::into_owned)
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         match (self, other) {
             (Ok(item), Ok(target)) => T::clone_onto(item, target),
             (Err(item), Err(target)) => E::clone_onto(item, target),

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -241,18 +241,16 @@ where
 {
     type Owned = Vec<C::Owned>;
 
-    fn into_owned(&self) -> Self::Owned {
-        self.iter()
-            .map(|item| IntoOwned::into_owned(&item))
-            .collect()
+    fn into_owned(self) -> Self::Owned {
+        self.iter().map(IntoOwned::into_owned).collect()
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         let r = std::cmp::min(self.len(), other.len());
         for (item, target) in self.iter().zip(other.iter_mut()) {
             item.clone_onto(target);
         }
-        other.extend(self.iter().skip(r).map(|item| IntoOwned::into_owned(&item)));
+        other.extend(self.iter().skip(r).map(IntoOwned::into_owned));
         other.truncate(self.len());
     }
 

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -241,16 +241,18 @@ where
 {
     type Owned = Vec<C::Owned>;
 
-    fn into_owned(self) -> Self::Owned {
-        self.iter().map(IntoOwned::into_owned).collect()
+    fn into_owned(&self) -> Self::Owned {
+        self.iter()
+            .map(|item| IntoOwned::into_owned(&item))
+            .collect()
     }
 
-    fn clone_onto(self, other: &mut Self::Owned) {
+    fn clone_onto(&self, other: &mut Self::Owned) {
         let r = std::cmp::min(self.len(), other.len());
         for (item, target) in self.iter().zip(other.iter_mut()) {
             item.clone_onto(target);
         }
-        other.extend(self.iter().skip(r).map(IntoOwned::into_owned));
+        other.extend(self.iter().skip(r).map(|item| IntoOwned::into_owned(&item)));
         other.truncate(self.len());
     }
 

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -218,7 +218,7 @@ where C: Region, O: OffsetContainer<C::Index>,
         todo!()
     }
 
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         todo!()
     }
 

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -64,6 +64,7 @@ impl<C: Region, O: OffsetContainer<C::Index>> Region for SliceRegion<C, O> {
     type ReadItem<'a> = ReadSlice<'a, C, O> where Self: 'a;
     type Index = (usize, usize);
 
+    #[inline]
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -100,11 +101,13 @@ impl<C: Region, O: OffsetContainer<C::Index>> Region for SliceRegion<C, O> {
         self.inner.clear();
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, mut callback: F) {
         self.slices.heap_size(&mut callback);
         self.inner.heap_size(callback);
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -114,6 +117,7 @@ impl<C: Region, O: OffsetContainer<C::Index>> Region for SliceRegion<C, O> {
 }
 
 impl<C: Region, O: OffsetContainer<C::Index>> Default for SliceRegion<C, O> {
+    #[inline]
     fn default() -> Self {
         Self {
             slices: O::default(),
@@ -241,10 +245,12 @@ where
 {
     type Owned = Vec<C::Owned>;
 
+    #[inline]
     fn into_owned(self) -> Self::Owned {
         self.iter().map(IntoOwned::into_owned).collect()
     }
 
+    #[inline]
     fn clone_onto(self, other: &mut Self::Owned) {
         let r = std::cmp::min(self.len(), other.len());
         for (item, target) in self.iter().zip(other.iter_mut()) {
@@ -254,6 +260,7 @@ where
         other.truncate(self.len());
     }
 
+    #[inline]
     fn borrow_as(owned: &'a Self::Owned) -> Self {
         Self(Err(owned.as_slice()))
     }
@@ -263,6 +270,7 @@ impl<'a, C: Region, O: OffsetContainer<C::Index>> IntoIterator for ReadSlice<'a,
     type Item = C::ReadItem<'a>;
     type IntoIter = ReadSliceIter<'a, C, O>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         match self.0 {
             Ok(inner) => {
@@ -280,6 +288,7 @@ pub struct ReadSliceIter<'a, C: Region, O: OffsetContainer<C::Index>>(
 );
 
 impl<'a, C: Region, O: OffsetContainer<C::Index>> Clone for ReadSliceIter<'a, C, O> {
+    #[inline]
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
@@ -293,6 +302,7 @@ pub struct ReadSliceIterInner<'a, C: Region, O: OffsetContainer<C::Index>>(
 );
 
 impl<'a, C: Region, O: OffsetContainer<C::Index>> Clone for ReadSliceIterInner<'a, C, O> {
+    #[inline]
     fn clone(&self) -> Self {
         Self(self.0, self.1.clone())
     }
@@ -339,6 +349,7 @@ where
     R: Region + ReserveItems<&'a T>,
     O: OffsetContainer<R::Index>,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a [T]> + Clone,
@@ -389,6 +400,7 @@ where
     for<'b> R: Region + ReserveItems<&'b T>,
     O: OffsetContainer<R::Index>,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a Vec<T>> + Clone,

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -33,7 +33,10 @@ pub struct OwnedRegion<T> {
     slices: Vec<T>,
 }
 
-impl<T> Region for OwnedRegion<T> where [T]: ToOwned {
+impl<T> Region for OwnedRegion<T>
+where
+    [T]: ToOwned,
+{
     type Owned = <[T] as ToOwned>::Owned;
     type ReadItem<'a> = &'a [T] where Self: 'a;
     type Index = (usize, usize);
@@ -110,7 +113,10 @@ impl<T> Default for OwnedRegion<T> {
     }
 }
 
-impl<T, const N: usize> Push<[T; N]> for OwnedRegion<T> where [T]: ToOwned {
+impl<T, const N: usize> Push<[T; N]> for OwnedRegion<T>
+where
+    [T]: ToOwned,
+{
     #[inline]
     fn push(&mut self, item: [T; N]) -> <OwnedRegion<T> as Region>::Index {
         let start = self.slices.len();
@@ -163,7 +169,10 @@ where
     }
 }
 
-impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T>where [T]: ToOwned  {
+impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T>
+where
+    [T]: ToOwned,
+{
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'b [T]> + Clone,
@@ -172,7 +181,10 @@ impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T>where [T]: ToOwned  {
     }
 }
 
-impl<T> Push<Vec<T>> for OwnedRegion<T> where [T]: ToOwned {
+impl<T> Push<Vec<T>> for OwnedRegion<T>
+where
+    [T]: ToOwned,
+{
     #[inline]
     fn push(&mut self, mut item: Vec<T>) -> <OwnedRegion<T> as Region>::Index {
         let start = self.slices.len();
@@ -188,7 +200,10 @@ impl<T: Clone> Push<&Vec<T>> for OwnedRegion<T> {
     }
 }
 
-impl<'a, T> ReserveItems<&'a Vec<T>> for OwnedRegion<T> where [T]: ToOwned {
+impl<'a, T> ReserveItems<&'a Vec<T>> for OwnedRegion<T>
+where
+    [T]: ToOwned,
+{
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a Vec<T>> + Clone,
@@ -206,7 +221,10 @@ impl<T: Clone, I: IntoIterator<Item = T>> Push<CopyIter<I>> for OwnedRegion<T> {
     }
 }
 
-impl<T, J: IntoIterator<Item = T>> ReserveItems<CopyIter<J>> for OwnedRegion<T>where [T]: ToOwned  {
+impl<T, J: IntoIterator<Item = T>> ReserveItems<CopyIter<J>> for OwnedRegion<T>
+where
+    [T]: ToOwned,
+{
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = CopyIter<J>> + Clone,

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{CopyIter, OpinionatedRegion, Push, Region, ReserveItems};
+use crate::{CopyIter, Push, Region, ReserveItems};
 
 /// A container for owned types.
 ///
@@ -81,27 +81,6 @@ where
         Self: 'a,
     {
         item
-    }
-}
-
-impl<T: Clone> OpinionatedRegion for OwnedRegion<T>
-where
-    [T]: ToOwned<Owned = Vec<T>>,
-{
-    fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
-        item.to_vec()
-    }
-    fn item_to_owned_into(item: Self::ReadItem<'_>, target: &mut Self::Owned) {
-        let mut valid = 0;
-        for (index, element) in item.iter().enumerate() {
-            if target.len() > index {
-                target[index].clone_from(element);
-            } else {
-                target.push(element.clone());
-            }
-            valid += 1;
-        }
-        target.truncate(valid);
     }
 }
 

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -33,7 +33,8 @@ pub struct OwnedRegion<T> {
     slices: Vec<T>,
 }
 
-impl<T> Region for OwnedRegion<T> {
+impl<T> Region for OwnedRegion<T> where [T]: ToOwned {
+    type Owned = <[T] as ToOwned>::Owned;
     type ReadItem<'a> = &'a [T] where Self: 'a;
     type Index = (usize, usize);
 
@@ -80,9 +81,10 @@ impl<T> Region for OwnedRegion<T> {
     }
 }
 
-impl<T: Clone> OpinionatedRegion for OwnedRegion<T> where [T]: ToOwned<Owned=Vec<T>>{
-    type Owned = Vec<T>;
-
+impl<T: Clone> OpinionatedRegion for OwnedRegion<T>
+where
+    [T]: ToOwned<Owned = Vec<T>>,
+{
     fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
         item.to_vec()
     }
@@ -108,7 +110,7 @@ impl<T> Default for OwnedRegion<T> {
     }
 }
 
-impl<T, const N: usize> Push<[T; N]> for OwnedRegion<T> {
+impl<T, const N: usize> Push<[T; N]> for OwnedRegion<T> where [T]: ToOwned {
     #[inline]
     fn push(&mut self, item: [T; N]) -> <OwnedRegion<T> as Region>::Index {
         let start = self.slices.len();
@@ -161,7 +163,7 @@ where
     }
 }
 
-impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T> {
+impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T>where [T]: ToOwned  {
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'b [T]> + Clone,
@@ -170,7 +172,7 @@ impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T> {
     }
 }
 
-impl<T> Push<Vec<T>> for OwnedRegion<T> {
+impl<T> Push<Vec<T>> for OwnedRegion<T> where [T]: ToOwned {
     #[inline]
     fn push(&mut self, mut item: Vec<T>) -> <OwnedRegion<T> as Region>::Index {
         let start = self.slices.len();
@@ -186,7 +188,7 @@ impl<T: Clone> Push<&Vec<T>> for OwnedRegion<T> {
     }
 }
 
-impl<'a, T> ReserveItems<&'a Vec<T>> for OwnedRegion<T> {
+impl<'a, T> ReserveItems<&'a Vec<T>> for OwnedRegion<T> where [T]: ToOwned {
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a Vec<T>> + Clone,
@@ -204,7 +206,7 @@ impl<T: Clone, I: IntoIterator<Item = T>> Push<CopyIter<I>> for OwnedRegion<T> {
     }
 }
 
-impl<T, J: IntoIterator<Item = T>> ReserveItems<CopyIter<J>> for OwnedRegion<T> {
+impl<T, J: IntoIterator<Item = T>> ReserveItems<CopyIter<J>> for OwnedRegion<T>where [T]: ToOwned  {
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = CopyIter<J>> + Clone,

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -41,6 +41,7 @@ where
     type ReadItem<'a> = &'a [T] where Self: 'a;
     type Index = (usize, usize);
 
+    #[inline]
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -55,6 +56,7 @@ where
         &self.slices[start..end]
     }
 
+    #[inline]
     fn reserve_regions<'a, I>(&mut self, regions: I)
     where
         Self: 'a,
@@ -68,6 +70,7 @@ where
         self.slices.clear();
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, mut callback: F) {
         let size_of_t = std::mem::size_of::<T>();
         callback(
@@ -76,6 +79,7 @@ where
         );
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -85,6 +89,7 @@ where
 }
 
 impl<T> Default for OwnedRegion<T> {
+    #[inline]
     fn default() -> Self {
         Self {
             slices: Vec::default(),
@@ -121,6 +126,7 @@ impl<T: Clone, const N: usize> Push<&&[T; N]> for OwnedRegion<T> {
 }
 
 impl<'b, T: Clone, const N: usize> ReserveItems<&'b [T; N]> for OwnedRegion<T> {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'b [T; N]> + Clone,
@@ -152,6 +158,7 @@ impl<'b, T> ReserveItems<&'b [T]> for OwnedRegion<T>
 where
     [T]: ToOwned,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'b [T]> + Clone,
@@ -183,6 +190,7 @@ impl<'a, T> ReserveItems<&'a Vec<T>> for OwnedRegion<T>
 where
     [T]: ToOwned,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'a Vec<T>> + Clone,
@@ -204,6 +212,7 @@ impl<T, J: IntoIterator<Item = T>> ReserveItems<CopyIter<J>> for OwnedRegion<T>
 where
     [T]: ToOwned,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = CopyIter<J>> + Clone,

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::impls::slice_copy::OwnedRegion;
-use crate::{Containerized, OpinionatedRegion, Push, Region, ReserveItems};
+use crate::{Containerized, Push, Region, ReserveItems};
 
 /// A region to store strings and read `&str`.
 ///
@@ -84,15 +84,6 @@ where
         Self: 'a,
     {
         item
-    }
-}
-
-impl OpinionatedRegion for StringRegion {
-    fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
-        item.to_string()
-    }
-    fn item_to_owned_into(item: Self::ReadItem<'_>, target: &mut Self::Owned) {
-        <str as ToOwned>::clone_into(item, target);
     }
 }
 
@@ -184,7 +175,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Push, ReadToOwned, Region, ReserveItems, StringRegion};
+    use crate::{IntoOwned, Push, Region, ReserveItems, StringRegion};
 
     #[test]
     fn test_inner() {
@@ -244,7 +235,7 @@ mod tests {
 
         let idx = r.push("abc");
         let reference = r.index(idx);
-        let owned = reference.read_to_owned();
+        let owned = reference.into_owned();
         let idx = r.push(owned);
         assert_eq!("abc", r.index(idx));
     }

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -47,6 +47,7 @@ where
     type ReadItem<'a> = &'a str where Self: 'a ;
     type Index = R::Index;
 
+    #[inline]
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -62,6 +63,7 @@ where
         unsafe { std::str::from_utf8_unchecked(self.inner.index(index)) }
     }
 
+    #[inline]
     fn reserve_regions<'a, I>(&mut self, regions: I)
     where
         Self: 'a,
@@ -75,10 +77,12 @@ where
         self.inner.clear();
     }
 
+    #[inline]
     fn heap_size<F: FnMut(usize, usize)>(&self, callback: F) {
         self.inner.heap_size(callback);
     }
 
+    #[inline]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
     where
         Self: 'a,
@@ -119,6 +123,7 @@ impl<'b, R> ReserveItems<&'b String> for StringRegion<R>
 where
     for<'a> R: Region<ReadItem<'a> = &'a [u8]> + ReserveItems<&'a [u8]> + 'a,
 {
+    #[inline]
     fn reserve_items<I>(&mut self, items: I)
     where
         I: Iterator<Item = &'b String> + Clone,

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::impls::slice_copy::OwnedRegion;
-use crate::{Containerized, Push, Region, ReserveItems};
+use crate::{Containerized, OpinionatedRegion, Push, Region, ReserveItems};
 
 /// A region to store strings and read `&str`.
 ///
@@ -83,6 +83,17 @@ where
         Self: 'a,
     {
         item
+    }
+}
+
+impl OpinionatedRegion for StringRegion {
+    type Owned = String;
+
+    fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
+        item.to_string()
+    }
+    fn item_to_owned_into(item: Self::ReadItem<'_>, target: &mut Self::Owned) {
+        <str as ToOwned>::clone_into(item, target);
     }
 }
 

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -174,7 +174,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Push, Region, ReserveItems, StringRegion};
+    use crate::{Push, ReadToOwned, Region, ReserveItems, StringRegion};
 
     #[test]
     fn test_inner() {
@@ -226,5 +226,16 @@ mod tests {
 
         assert!(cap > 0);
         assert!(cnt > 0);
+    }
+
+    #[test]
+    fn owned() {
+        let mut r = <StringRegion>::default();
+
+        let idx = r.push("abc");
+        let reference = r.index(idx);
+        let owned = reference.read_to_owned();
+        let idx = r.push(owned);
+        assert_eq!("abc", r.index(idx));
     }
 }

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -43,6 +43,7 @@ impl<R> Region for StringRegion<R>
 where
     for<'a> R: Region<ReadItem<'a> = &'a [u8]> + 'a,
 {
+    type Owned = String;
     type ReadItem<'a> = &'a str where Self: 'a ;
     type Index = R::Index;
 
@@ -87,8 +88,6 @@ where
 }
 
 impl OpinionatedRegion for StringRegion {
-    type Owned = String;
-
     fn item_to_owned(item: Self::ReadItem<'_>) -> Self::Owned {
         item.to_string()
     }

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -4,7 +4,7 @@ use paste::paste;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{Containerized, Push, Region, ReserveItems};
+use crate::{Containerized, IntoOwned, Push, Region, ReserveItems};
 
 /// The macro creates the region implementation for tuples
 macro_rules! tuple_flatcontainer {
@@ -27,6 +27,7 @@ macro_rules! tuple_flatcontainer {
             where
                $(<$name as Region>::Index: crate::Index),*
             {
+                type Owned = ($($name::Owned,)*);
                 type ReadItem<'a> = ($($name::ReadItem<'a>,)*) where Self: 'a;
 
                 type Index = ($($name::Index,)*);
@@ -96,6 +97,27 @@ macro_rules! tuple_flatcontainer {
                     -> <[<Tuple $($name)* Region>]<$([<$name _C>]),*> as Region>::Index {
                     let ($($name,)*) = item;
                     ($(self.[<container $name>].push($name),)*)
+                }
+            }
+
+            #[allow(non_camel_case_types)]
+            #[allow(non_snake_case)]
+            impl<'a, $($name),*> IntoOwned<'a> for ($($name,)*)
+            where
+                $($name: IntoOwned<'a>),*
+            {
+                type Owned = ($($name::Owned,)*);
+
+                fn into_owned(self) -> Self::Owned {
+                    todo!()
+                }
+
+                fn clone_onto(&self, other: &mut Self::Owned) {
+                    todo!()
+                }
+
+                fn borrow_as(owned: &'a Self::Owned) -> Self {
+                    todo!()
                 }
             }
 

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -108,14 +108,14 @@ macro_rules! tuple_flatcontainer {
             {
                 type Owned = ($($name::Owned,)*);
 
-                fn into_owned(&self) -> Self::Owned {
+                fn into_owned(self) -> Self::Owned {
                     let ($($name,)*) = self;
                     (
                         $($name.into_owned(),)*
                     )
                 }
 
-                fn clone_onto(&self, other: &mut Self::Owned) {
+                fn clone_onto(self, other: &mut Self::Owned) {
                     let ($($name,)*) = self;
                     let ($([<$name _other>],)*) = other;
                     $($name.clone_onto([<$name _other>]);)*

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -109,15 +109,23 @@ macro_rules! tuple_flatcontainer {
                 type Owned = ($($name::Owned,)*);
 
                 fn into_owned(self) -> Self::Owned {
-                    todo!()
+                    let ($($name,)*) = self;
+                    (
+                        $($name.into_owned(),)*
+                    )
                 }
 
                 fn clone_onto(self, other: &mut Self::Owned) {
-                    todo!()
+                    let ($($name,)*) = self;
+                    let ($([<$name _other>],)*) = other;
+                    $($name.clone_onto([<$name _other>]);)*
                 }
 
                 fn borrow_as(owned: &'a Self::Owned) -> Self {
-                    todo!()
+                    let ($($name,)*) = owned;
+                    (
+                        $($name::borrow_as($name),)*
+                    )
                 }
             }
 

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -32,6 +32,7 @@ macro_rules! tuple_flatcontainer {
 
                 type Index = ($($name::Index,)*);
 
+                #[inline]
                 fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
                 where
                     Self: 'a,
@@ -62,10 +63,12 @@ macro_rules! tuple_flatcontainer {
                     $(self.[<container $name>].clear();)*
                 }
 
+                #[inline]
                 fn heap_size<Fn: FnMut(usize, usize)>(&self, mut callback: Fn) {
                     $(self.[<container $name>].heap_size(&mut callback);)*
                 }
 
+                #[inline]
                 fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> where Self: 'a {
                     let ($($name,)*) = item;
                     (
@@ -80,6 +83,7 @@ macro_rules! tuple_flatcontainer {
             where
                 $([<$name _C>]: Push<$name>),*
             {
+                #[inline]
                 fn push(&mut self, item: ($($name,)*))
                     -> <[<Tuple $($name)* Region>]<$([<$name _C>]),*> as Region>::Index {
                     let ($($name,)*) = item;
@@ -93,6 +97,7 @@ macro_rules! tuple_flatcontainer {
             where
                 $([<$name _C>]: Region + Push<&'a $name>),*
             {
+                #[inline]
                 fn push(&mut self, item: &'a ($($name,)*))
                     -> <[<Tuple $($name)* Region>]<$([<$name _C>]),*> as Region>::Index {
                     let ($($name,)*) = item;
@@ -108,6 +113,7 @@ macro_rules! tuple_flatcontainer {
             {
                 type Owned = ($($name::Owned,)*);
 
+                #[inline]
                 fn into_owned(self) -> Self::Owned {
                     let ($($name,)*) = self;
                     (
@@ -115,12 +121,14 @@ macro_rules! tuple_flatcontainer {
                     )
                 }
 
+                #[inline]
                 fn clone_onto(self, other: &mut Self::Owned) {
                     let ($($name,)*) = self;
                     let ($([<$name _other>],)*) = other;
                     $($name.clone_onto([<$name _other>]);)*
                 }
 
+                #[inline]
                 fn borrow_as(owned: &'a Self::Owned) -> Self {
                     let ($($name,)*) = owned;
                     (
@@ -135,6 +143,7 @@ macro_rules! tuple_flatcontainer {
             where
                 $([<$name _C>]: Region + ReserveItems<&'a $name>),*
             {
+                #[inline]
                 fn reserve_items<It>(&mut self, items: It)
                 where
                     It: Iterator<Item = &'a ($($name,)*)> + Clone,
@@ -149,6 +158,7 @@ macro_rules! tuple_flatcontainer {
             where
                 $([<$name _C>]: Region + ReserveItems<$name>),*
             {
+                #[inline]
                 fn reserve_items<It>(&mut self, items: It)
                 where
                     It: Iterator<Item = ($($name,)*)> + Clone,

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -108,14 +108,14 @@ macro_rules! tuple_flatcontainer {
             {
                 type Owned = ($($name::Owned,)*);
 
-                fn into_owned(self) -> Self::Owned {
+                fn into_owned(&self) -> Self::Owned {
                     let ($($name,)*) = self;
                     (
                         $($name.into_owned(),)*
                     )
                 }
 
-                fn clone_onto(self, other: &mut Self::Owned) {
+                fn clone_onto(&self, other: &mut Self::Owned) {
                     let ($($name,)*) = self;
                     let ($([<$name _other>],)*) = other;
                     $($name.clone_onto([<$name _other>]);)*

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -112,7 +112,7 @@ macro_rules! tuple_flatcontainer {
                     todo!()
                 }
 
-                fn clone_onto(&self, other: &mut Self::Owned) {
+                fn clone_onto(self, other: &mut Self::Owned) {
                     todo!()
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,7 +789,7 @@ mod tests {
 
         let mut c = <StringRegion>::default();
         let index = c.push("abc".to_string());
-        owned_roundtrip(&mut c, index);
+        owned_roundtrip::<StringRegion, String>(&mut c, index);
     }
 
     /// Test that items and owned variants can be reborrowed to shorten their lifetimes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,15 +475,25 @@ mod tests {
         type Owned = Person;
 
         fn into_owned(self) -> Self::Owned {
-            todo!()
+            Person {
+                name: self.name.into_owned(),
+                age: self.age,
+                hobbies: self.hobbies.into_owned(),
+            }
         }
 
         fn clone_onto(self, other: &mut Self::Owned) {
-            todo!()
+            self.name.clone_onto(&mut other.name);
+            other.age = self.age;
+            self.hobbies.clone_onto(&mut other.hobbies);
         }
 
         fn borrow_as(owned: &'a Self::Owned) -> Self {
-            todo!()
+            Self {
+                name: IntoOwned::borrow_as(&owned.name),
+                age: owned.age,
+                hobbies: IntoOwned::borrow_as(&owned.hobbies),
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub trait IntoOwned<'a> {
     /// Conversion from an instance of this type to the owned type.
     fn into_owned(self) -> Self::Owned;
     /// Clones `self` onto an existing instance of the owned type.
-    fn clone_onto(&self, other: &mut Self::Owned);
+    fn clone_onto(self, other: &mut Self::Owned);
     /// Borrows an owned instance as oneself.
     fn borrow_as(owned: &'a Self::Owned) -> Self;
 }
@@ -125,7 +125,7 @@ impl<'a, T: ToOwned + ?Sized> IntoOwned<'a> for &'a T {
     fn into_owned(self) -> Self::Owned {
         self.to_owned()
     }
-    fn clone_onto(&self, other: &mut Self::Owned) {
+    fn clone_onto(self, other: &mut Self::Owned) {
         <T as ToOwned>::clone_into(self, other)
     }
     fn borrow_as(owned: &'a Self::Owned) -> Self {
@@ -478,7 +478,7 @@ mod tests {
             todo!()
         }
 
-        fn clone_onto(&self, other: &mut Self::Owned) {
+        fn clone_onto(self, other: &mut Self::Owned) {
             todo!()
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,4 +795,154 @@ mod tests {
         // let _ = item == IntoOwned::borrow_as(owned);
         let _ = R::reborrow(item) == R::reborrow(IntoOwned::borrow_as(owned));
     }
+
+    mod cow {
+        //! What follows is an example of a Cow-like type that can be used to switch between a GAT
+        //! and an owned type at runtime.
+
+        use std::convert::Infallible;
+        use std::fmt::{Debug, Formatter};
+        use crate::{FlatStack, IntoOwned, Push, Region, StringRegion};
+
+        #[allow(dead_code)]
+        enum GatCow<'a, B, T> {
+            Borrowed(B),
+            Owned(T),
+            Never(&'a Infallible),
+        }
+
+        impl<'a, B, T> GatCow<'a, B, T>
+        where
+            B: IntoOwned<'a, Owned = T> + Copy,
+        {
+            pub fn to_mut(&mut self) -> &mut T {
+                match self {
+                    Self::Borrowed(borrowed) => {
+                        *self = Self::Owned(borrowed.into_owned());
+                        match *self {
+                            Self::Borrowed(..) => unreachable!(),
+                            Self::Owned(ref mut owned) => owned,
+                            Self::Never(_) => unreachable!(),
+                        }
+                    }
+                    Self::Owned(ref mut owned) => owned,
+                    Self::Never(_) => unreachable!(),
+                }
+            }
+        }
+
+        impl<'a, B, T> IntoOwned<'a> for GatCow<'a, B, T>
+        where
+            B: IntoOwned<'a, Owned = T> + Copy,
+        {
+            type Owned = T;
+
+            fn into_owned(self) -> T {
+                match self {
+                    GatCow::Borrowed(b) => b.into_owned(),
+                    GatCow::Owned(o) => o,
+                    Self::Never(_) => unreachable!(),
+                }
+            }
+
+            fn clone_onto(self, other: &mut T) {
+                match self {
+                    GatCow::Borrowed(b) => b.clone_onto(other),
+                    GatCow::Owned(o) => *other = o,
+                    Self::Never(_) => unreachable!(),
+                }
+            }
+
+            fn borrow_as(owned: &'a T) -> Self {
+                GatCow::Borrowed(IntoOwned::borrow_as(owned))
+            }
+        }
+
+        impl<B, T> Debug for GatCow<'_, B, T>
+        where
+            B: Debug,
+            T: Debug,
+        {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    GatCow::Borrowed(b) => b.fmt(f),
+                    GatCow::Owned(o) => o.fmt(f),
+                    Self::Never(_) => unreachable!(),
+                }
+            }
+        }
+
+        #[derive(Default, Debug, Clone)]
+        struct CowRegion<R>(R);
+
+        impl<R> Region for CowRegion<R>
+        where
+            R: Region,
+            for<'a> R::ReadItem<'a>: Copy,
+        {
+            type Owned = <R as Region>::Owned;
+            type ReadItem<'a> = GatCow<'a, R::ReadItem<'a>, R::Owned> where Self: 'a;
+            type Index = R::Index;
+
+            fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
+            where
+                Self: 'a,
+            {
+                Self(R::merge_regions(regions.map(|r| &r.0)))
+            }
+
+            fn index(&self, index: Self::Index) -> Self::ReadItem<'_> {
+                GatCow::Borrowed(self.0.index(index))
+            }
+
+            fn reserve_regions<'a, I>(&mut self, regions: I)
+            where
+                Self: 'a,
+                I: Iterator<Item = &'a Self> + Clone,
+            {
+                self.0.reserve_regions(regions.map(|r| &r.0))
+            }
+
+            fn clear(&mut self) {
+                self.0.clear()
+            }
+
+            fn heap_size<F: FnMut(usize, usize)>(&self, callback: F) {
+                self.0.heap_size(callback)
+            }
+
+            fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+            where
+                Self: 'a,
+            {
+                match item {
+                    GatCow::Borrowed(b) => GatCow::Borrowed(R::reborrow(b)),
+                    GatCow::Owned(o) => GatCow::Owned(o),
+                    GatCow::Never(_) => unreachable!(),
+                }
+            }
+        }
+
+        impl<R, D> Push<D> for CowRegion<R>
+        where
+            R: Region + Push<D>,
+            for<'a> R::ReadItem<'a>: Copy,
+        {
+            fn push(&mut self, item: D) -> Self::Index {
+                self.0.push(item)
+            }
+        }
+
+        #[test]
+        fn test_gat_cow() {
+            let mut c = <FlatStack<CowRegion<StringRegion>>>::default();
+            c.copy("abc");
+
+            assert_eq!("abc", c.get(0).into_owned());
+            let mut item = c.get(0);
+            item.to_mut().push_str("def");
+            assert_eq!("abcdef", item.into_owned());
+            assert_eq!("abc", c.get(0).into_owned());
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,19 +113,22 @@ pub trait IntoOwned<'a> {
     /// Owned type into which this type can be converted.
     type Owned;
     /// Conversion from an instance of this type to the owned type.
-    fn into_owned(self) -> Self::Owned;
+    fn into_owned(&self) -> Self::Owned;
     /// Clones `self` onto an existing instance of the owned type.
-    fn clone_onto(self, other: &mut Self::Owned);
+    fn clone_onto(&self, other: &mut Self::Owned);
     /// Borrows an owned instance as oneself.
     fn borrow_as(owned: &'a Self::Owned) -> Self;
 }
 
-impl<'a, T: ToOwned + ?Sized> IntoOwned<'a> for &'a T {
+impl<'a, T> IntoOwned<'a> for &'a T
+where
+    T: ToOwned + ?Sized,
+{
     type Owned = T::Owned;
-    fn into_owned(self) -> Self::Owned {
-        self.to_owned()
+    fn into_owned(&self) -> Self::Owned {
+        (*self).to_owned()
     }
-    fn clone_onto(self, other: &mut Self::Owned) {
+    fn clone_onto(&self, other: &mut Self::Owned) {
         <T as ToOwned>::clone_into(self, other)
     }
     fn borrow_as(owned: &'a Self::Owned) -> Self {
@@ -435,7 +438,7 @@ mod tests {
     impl<'a> IntoOwned<'a> for PersonRef<'a> {
         type Owned = Person;
 
-        fn into_owned(self) -> Self::Owned {
+        fn into_owned(&self) -> Self::Owned {
             Person {
                 name: self.name.into_owned(),
                 age: self.age,
@@ -443,7 +446,7 @@ mod tests {
             }
         }
 
-        fn clone_onto(self, other: &mut Self::Owned) {
+        fn clone_onto(&self, other: &mut Self::Owned) {
             self.name.clone_onto(&mut other.name);
             other.age = self.age;
             self.hobbies.clone_onto(&mut other.hobbies);
@@ -766,8 +769,7 @@ mod tests {
             for<'a> R: Region + Push<<<R as Region>::ReadItem<'a> as IntoOwned<'a>>::Owned>,
             for<'a> R::ReadItem<'a>: IntoOwned<'a, Owned = O> + Eq + Debug,
         {
-            let item = region.index(index);
-            let owned = item.into_owned();
+            let owned = region.index(index).into_owned();
             let index2 = region.push(owned);
             let item = region.index(index);
             assert_eq!(item, region.index(index2));


### PR DESCRIPTION
Adds a `Owned` type to `Region`, with the added constraint that `R::ReadItem<'_>: IntoOwned<'_, R::Owned>`. Also adds a `IntoOwned` trait that is similar to Rust's `ToOwned`, without the requirement that the type must also be `Borrow`.