### PR TITLE
Introduce reborrow to enable lifetime variance

### DIFF
--- a/src/impls/codec.rs
+++ b/src/impls/codec.rs
@@ -110,6 +110,13 @@ where
         self.inner.heap_size(&mut callback);
         self.codec.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        C: 'a,
+    {
+        item
+    }
 }
 
 impl<C: Codec, R> Push<&[u8]> for CodecRegion<C, R>

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -133,6 +133,13 @@ where
         }
         self.indices.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item
+    }
 }
 
 impl<R> Default for ColumnsRegion<R>

--- a/src/impls/deduplicate.rs
+++ b/src/impls/deduplicate.rs
@@ -70,6 +70,13 @@ impl<R: Region> Region for CollapseSequence<R> {
     fn heap_size<F: FnMut(usize, usize)>(&self, callback: F) {
         self.inner.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        R::reborrow(item)
+    }
 }
 
 impl<R, T> Push<T> for CollapseSequence<R>
@@ -135,8 +142,10 @@ impl<R: Region<Index = (usize, usize)>, O: OffsetContainer<usize>> Default
     }
 }
 
-impl<R: Region<Index = (usize, usize)>, O: OffsetContainer<usize>> Region
-    for ConsecutiveOffsetPairs<R, O>
+impl<R, O> Region for ConsecutiveOffsetPairs<R, O>
+where
+    R: Region<Index = (usize, usize)>,
+    O: OffsetContainer<usize>,
 {
     type ReadItem<'a> = R::ReadItem<'a>
     where
@@ -180,6 +189,13 @@ impl<R: Region<Index = (usize, usize)>, O: OffsetContainer<usize>> Region
     fn heap_size<F: FnMut(usize, usize)>(&self, mut callback: F) {
         self.offsets.heap_size(&mut callback);
         self.inner.heap_size(callback);
+    }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        R::reborrow(item)
     }
 }
 

--- a/src/impls/mirror.rs
+++ b/src/impls/mirror.rs
@@ -73,6 +73,13 @@ impl<T: Index> Region for MirrorRegion<T> {
     fn heap_size<F: FnMut(usize, usize)>(&self, _callback: F) {
         // No storage
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item
+    }
 }
 
 impl<T: Index> Push<T> for MirrorRegion<T> {

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -66,6 +66,13 @@ impl<R: Region> Region for OptionRegion<R> {
     fn heap_size<F: FnMut(usize, usize)>(&self, callback: F) {
         self.inner.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item.map(R::reborrow)
+    }
 }
 
 impl<T, TR> Push<Option<T>> for OptionRegion<TR>

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -78,6 +78,13 @@ where
         self.oks.heap_size(&mut callback);
         self.errs.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item.map(T::reborrow).map_err(E::reborrow)
+    }
 }
 
 impl<T, TC, E, EC> Push<Result<T, E>> for ResultRegion<TC, EC>

--- a/src/impls/slice.rs
+++ b/src/impls/slice.rs
@@ -103,6 +103,13 @@ impl<C: Region, O: OffsetContainer<C::Index>> Region for SliceRegion<C, O> {
         self.slices.heap_size(&mut callback);
         self.inner.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item
+    }
 }
 
 impl<C: Region, O: OffsetContainer<C::Index>> Default for SliceRegion<C, O> {

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -71,6 +71,13 @@ impl<T> Region for OwnedRegion<T> {
             self.slices.capacity() * size_of_t,
         );
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item
+    }
 }
 
 impl<T> Default for OwnedRegion<T> {

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -77,6 +77,13 @@ where
     fn heap_size<F: FnMut(usize, usize)>(&self, callback: F) {
         self.inner.heap_size(callback);
     }
+
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a,
+    {
+        item
+    }
 }
 
 impl Containerized for String {

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -64,6 +64,13 @@ macro_rules! tuple_flatcontainer {
                 fn heap_size<Fn: FnMut(usize, usize)>(&self, mut callback: Fn) {
                     $(self.[<container $name>].heap_size(&mut callback);)*
                 }
+
+                fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> where Self: 'a {
+                    let ($($name,)*) = item;
+                    (
+                        $($name::reborrow($name),)*
+                    )
+                }
             }
 
             #[allow(non_camel_case_types)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,11 @@ pub trait Region: Default {
 
     /// Heap size, size - capacity
     fn heap_size<F: FnMut(usize, usize)>(&self, callback: F);
+
+    /// Converts a read item into one with a narrower lifetime.
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+    where
+        Self: 'a;
 }
 
 /// A trait to let types express a default container type.
@@ -449,6 +454,17 @@ mod tests {
             self.name_container.heap_size(&mut callback);
             self.age_container.heap_size(&mut callback);
             self.hobbies.heap_size(callback);
+        }
+
+        fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b>
+        where
+            Self: 'a,
+        {
+            PersonRef {
+                name: <String as Containerized>::Region::reborrow(item.name),
+                age: <u16 as Containerized>::Region::reborrow(item.age),
+                hobbies: <Vec<String> as Containerized>::Region::reborrow(item.hobbies),
+            }
         }
     }
 


### PR DESCRIPTION
Add `Region::reborrow` to shorten the lifetime of the read item to enable lifetime variance for users of the crate. This serves to overcome a limit where Rust does not infer appropriate lifetimes when unifying two different lifetimes.
