### PR TITLE
Efficient cloning of regions and flat stack

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -263,6 +263,124 @@ fn vec_u_vn_s_prealloc(bencher: &mut Bencher) {
     );
 }
 
+#[bench]
+fn empty_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec![(); 1024]);
+}
+#[bench]
+fn u64_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec![0u64; 1024]);
+}
+#[bench]
+fn u32x2_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec![(0u32, 0u32); 1024]);
+}
+#[bench]
+fn u8_u64_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec![(0u8, 0u64); 512]);
+}
+#[bench]
+fn str10_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec!["grawwwwrr!"; 1024]);
+}
+#[bench]
+fn str100_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec!["grawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrr!!!!!!!!!grawwwwrr!"; 1024]);
+}
+#[bench]
+fn string10_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec![format!("grawwwwrr!"); 1024]);
+}
+#[bench]
+fn string20_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(bencher, vec![format!("grawwwwrr!!!!!!!!!!!"); 512]);
+}
+#[bench]
+fn vec_u_s_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(
+        bencher,
+        vec![vec![(0u64, "grawwwwrr!".to_string()); 32]; 32],
+    );
+}
+#[bench]
+fn vec_u_vn_s_copy_flat(bencher: &mut Bencher) {
+    _bench_copy_flat_containerized(
+        bencher,
+        vec![vec![(0u64, vec![(); 1 << 40], "grawwwwrr!".to_string()); 32]; 32],
+    );
+}
+
+#[bench]
+fn empty_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<OwnedRegion<_>, _>(bencher, vec![(); 1024]);
+}
+#[bench]
+fn u64_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<OwnedRegion<_>, _>(bencher, vec![0u64; 1024]);
+}
+#[bench]
+fn u32x2_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<OwnedRegion<_>, _>(bencher, vec![(0u32, 0u32); 1024]);
+}
+#[bench]
+fn u8_u64_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<OwnedRegion<_>, _>(bencher, vec![(0u8, 0u64); 512]);
+}
+#[bench]
+fn str10_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<OwnedRegion<_>, _>(bencher, vec!["grawwwwrr!"; 1024]);
+}
+#[bench]
+fn str100_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<OwnedRegion<_>, _>(bencher, vec!["grawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrrgrawwwwrr!!!!!!!!!grawwwwrr!"; 1024]);
+}
+#[bench]
+fn string10_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<SliceRegion<StringRegion>, _>(bencher, vec![format!("grawwwwrr!"); 1024]);
+}
+#[bench]
+fn string20_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<SliceRegion<StringRegion>, _>(
+        bencher,
+        vec![format!("grawwwwrr!!!!!!!!!!!"); 512],
+    );
+}
+#[bench]
+fn vec_u_s_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<SliceRegion<SliceRegion<TupleABRegion<MirrorRegion<_>, StringRegion>>>, _>(
+        bencher,
+        vec![vec![(0u64, "grawwwwrr!".to_string()); 32]; 32],
+    );
+}
+#[bench]
+fn vec_u_vn_s_copy_flat_region(bencher: &mut Bencher) {
+    _bench_copy_flat::<
+        SliceRegion<SliceRegion<TupleABCRegion<MirrorRegion<_>, OwnedRegion<_>, StringRegion>>>,
+        _,
+    >(
+        bencher,
+        vec![vec![(0u64, vec![(); 1 << 40], "grawwwwrr!".to_string()); 32]; 32],
+    );
+}
+#[bench]
+fn vec_u_vn_s_copy_flat_region_column(bencher: &mut Bencher) {
+    _bench_copy_flat::<
+        SliceRegion<
+            ColumnsRegion<
+                TupleABCRegion<
+                    MirrorRegion<_>,
+                    CollapseSequence<OwnedRegion<_>>,
+                    CollapseSequence<StringRegion>,
+                >,
+            >,
+        >,
+        _,
+    >(
+        bencher,
+        vec![vec![(0u64, vec![(); 1 << 40], "grawwwwrr!".to_string()); 32]; 32],
+    );
+}
+
 fn _bench_copy<T: Containerized + Eq>(bencher: &mut Bencher, record: T)
 where
     for<'a> <T as Containerized>::Region: Push<&'a T>,
@@ -281,6 +399,7 @@ where
         siz += this_siz;
         cap += this_cap
     });
+    bencher.bytes = siz as u64;
     println!("{siz} {cap}");
 }
 
@@ -302,6 +421,7 @@ where
         siz += this_siz;
         cap += this_cap
     });
+    bencher.bytes = siz as u64;
     println!("{siz} {cap}");
 }
 
@@ -321,25 +441,71 @@ fn _bench_realloc<T: Containerized + Eq>(bencher: &mut Bencher, record: T)
 where
     for<'a> <T as Containerized>::Region: Push<&'a T>,
 {
+    let mut arena = FlatStack::default_impl::<T>();
     bencher.iter(|| {
         // prepare encoded data for bencher.bytes
-        let mut arena = FlatStack::default_impl::<T>();
+        arena = FlatStack::default_impl::<T>();
         for _ in 0..1024 {
             arena.copy(&record);
         }
     });
+    let (mut siz, mut cap) = (0, 0);
+    arena.heap_size(|this_siz, this_cap| {
+        siz += this_siz;
+        cap += this_cap
+    });
+    bencher.bytes = siz as u64;
 }
 
 fn _bench_prealloc<T: Containerized + Eq>(bencher: &mut Bencher, record: T)
 where
     for<'a> <T as Containerized>::Region: ReserveItems<&'a T> + Push<&'a T>,
 {
+    let mut arena = FlatStack::default_impl::<T>();
     bencher.iter(|| {
+        arena = FlatStack::default_impl::<T>();
         // prepare encoded data for bencher.bytes
-        let mut arena = FlatStack::default_impl::<T>();
         arena.reserve_items(std::iter::repeat(&record).take(1024));
         for _ in 0..1024 {
             arena.copy(&record);
         }
     });
+    let (mut siz, mut cap) = (0, 0);
+    arena.heap_size(|this_siz, this_cap| {
+        siz += this_siz;
+        cap += this_cap
+    });
+    bencher.bytes = siz as u64;
+}
+
+fn _bench_copy_flat_containerized<T>(bencher: &mut Bencher, record: T)
+where
+    T: Containerized,
+    for<'a> <T as Containerized>::Region:
+        Push<&'a T> + Push<<<T as Containerized>::Region as Region>::ReadItem<'a>> + Clone,
+{
+    _bench_copy_flat::<T::Region, T>(bencher, record)
+}
+
+fn _bench_copy_flat<R, T>(bencher: &mut Bencher, record: T)
+where
+    for<'a> R: Region + Push<&'a T> + Push<<R as Region>::ReadItem<'a>> + Clone,
+{
+    // prepare encoded data for bencher.bytes
+    let mut arena = FlatStack::<R>::default();
+    for _ in 0..1024 {
+        arena.copy(&record);
+    }
+    let mut target = FlatStack::<R>::default();
+
+    bencher.iter(|| {
+        target.clone_from(&arena);
+    });
+    let (mut siz, mut cap) = (0, 0);
+    arena.heap_size(|this_siz, this_cap| {
+        siz += this_siz;
+        cap += this_cap
+    });
+    bencher.bytes = siz as u64;
+    println!("{siz} {cap}");
 }

--- a/src/impls/codec.rs
+++ b/src/impls/codec.rs
@@ -62,10 +62,23 @@ fn consolidate_slice<T: Ord>(slice: &mut [(T, usize)]) -> usize {
 }
 
 /// A region that encodes its data in a codec `C`.
-#[derive(Default, Debug, Clone)]
-pub struct CodecRegion<C: Codec, R = OwnedRegion<u8>> {
+#[derive(Default, Debug)]
+pub struct CodecRegion<C, R = OwnedRegion<u8>> {
     inner: R,
     codec: C,
+}
+
+impl<C: Clone, R: Clone> Clone for CodecRegion<C, R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            codec: self.codec.clone(),
+        }
+    }
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+        self.codec.clone_from(&source.codec);
+    }
 }
 
 impl<C: Codec, R> Region for CodecRegion<C, R>
@@ -104,6 +117,7 @@ where
     }
 
     fn clear(&mut self) {
+        self.inner.clear();
         self.codec = Default::default();
     }
 

--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -48,7 +48,7 @@ use crate::{OwnedRegion, Push, Region};
 ///     assert!(row.iter().copied().eq(r.index(index).iter()));
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -65,6 +65,23 @@ where
     indices: ConsecutiveOffsetPairs<OwnedRegion<R::Index>, OffsetOptimized>,
     /// Storage for columns.
     inner: Vec<R>,
+}
+
+impl<R> Clone for ColumnsRegion<R>
+where
+    R: Region + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            indices: self.indices.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.indices.clone_from(&source.indices);
+        self.inner.clone_from(&source.inner);
+    }
 }
 
 impl<R> Region for ColumnsRegion<R>

--- a/src/impls/deduplicate.rs
+++ b/src/impls/deduplicate.rs
@@ -18,13 +18,27 @@ use crate::{Push, Region, ReserveItems};
 ///
 /// assert_eq!(r.push("abc"), r.push("abc"));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CollapseSequence<R: Region> {
     /// Inner region.
     inner: R,
     /// The index of the last pushed item.
     last_index: Option<R::Index>,
+}
+
+impl<R: Region + Clone> Clone for CollapseSequence<R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            last_index: self.last_index,
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+        self.last_index = source.last_index;
+    }
 }
 
 impl<R: Region> Default for CollapseSequence<R> {
@@ -114,13 +128,9 @@ where
 /// let index: usize = r.push(&b"abc");
 /// assert_eq!(b"abc", r.index(index));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct ConsecutiveOffsetPairs<R, O = OffsetOptimized>
-where
-    R: Region<Index = (usize, usize)>,
-    O: OffsetContainer<usize>,
-{
+pub struct ConsecutiveOffsetPairs<R, O = OffsetOptimized> {
     /// Wrapped region
     inner: R,
     /// Storage for offsets. Always stores element 0.
@@ -129,8 +139,26 @@ where
     last_index: usize,
 }
 
-impl<R: Region<Index = (usize, usize)>, O: OffsetContainer<usize>> Default
-    for ConsecutiveOffsetPairs<R, O>
+impl<R: Clone, O: Clone> Clone for ConsecutiveOffsetPairs<R, O> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            offsets: self.offsets.clone(),
+            last_index: self.last_index,
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+        self.offsets.clone_from(&source.offsets);
+        self.last_index = source.last_index;
+    }
+}
+
+impl<R, O> Default for ConsecutiveOffsetPairs<R, O>
+where
+    R: Default,
+    O: OffsetContainer<usize>,
 {
     #[inline]
     fn default() -> Self {

--- a/src/impls/huffman_container.rs
+++ b/src/impls/huffman_container.rs
@@ -33,6 +33,20 @@ where
     }
 }
 
+impl<B: Ord + Clone> Clone for HuffmanContainer<B> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            stats: self.stats.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+        self.stats.clone_from(&source.stats);
+    }
+}
+
 impl<B> Region for HuffmanContainer<B>
 where
     B: Ord + Clone + Sized + 'static,
@@ -462,6 +476,21 @@ mod huffman {
         /// Byte-by-byte decoder.
         decode: [Decode<T>; 256],
     }
+
+    impl<T: Ord + Clone> Clone for Huffman<T> {
+        fn clone(&self) -> Self {
+            Self {
+                encode: self.encode.clone(),
+                decode: self.decode.clone(),
+            }
+        }
+
+        fn clone_from(&mut self, source: &Self) {
+            self.encode.clone_from(&source.encode);
+            self.decode.clone_from(&source.decode);
+        }
+    }
+
     impl<T: Ord> Huffman<T> {
         /// Encodes the provided symbols as a sequence of bytes.
         ///
@@ -578,7 +607,7 @@ mod huffman {
     }
 
     /// Decoder
-    #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Default)]
+    #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Default, Clone)]
     pub enum Decode<T> {
         /// An as-yet unfilled slot.
         #[default]

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -25,10 +25,22 @@ impl<T: Containerized> Containerized for Option<T> {
 /// assert_eq!(Some(123), r.index(some_index));
 /// assert_eq!(None, r.index(none_index));
 /// ```
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OptionRegion<R> {
     inner: R,
+}
+
+impl<R: Clone> Clone for OptionRegion<R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+    }
 }
 
 impl<R: Region> Region for OptionRegion<R> {

--- a/src/impls/result.rs
+++ b/src/impls/result.rs
@@ -25,11 +25,25 @@ impl<T: Containerized, E: Containerized> Containerized for Result<T, E> {
 /// assert_eq!(Ok(()), r.index(ok_index));
 /// assert_eq!(Err("Error"), r.index(err_index));
 /// ```
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResultRegion<T, E> {
     oks: T,
     errs: E,
+}
+
+impl<T: Clone, E: Clone> Clone for ResultRegion<T, E> {
+    fn clone(&self) -> Self {
+        Self {
+            oks: self.oks.clone(),
+            errs: self.errs.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.oks.clone_from(&source.oks);
+        self.errs.clone_from(&source.errs);
+    }
 }
 
 impl<T, E> Region for ResultRegion<T, E>

--- a/src/impls/slice_copy.rs
+++ b/src/impls/slice_copy.rs
@@ -27,10 +27,22 @@ use crate::{CopyIter, Push, Region, ReserveItems};
 /// assert_eq!(panagram_de.as_bytes(), r.index(de_index));
 /// assert_eq!(panagram_en.as_bytes(), r.index(en_index));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OwnedRegion<T> {
     slices: Vec<T>,
+}
+
+impl<T: Clone> Clone for OwnedRegion<T> {
+    fn clone(&self) -> Self {
+        Self {
+            slices: self.slices.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.slices.clone_from(&source.slices);
+    }
 }
 
 impl<T> Region for OwnedRegion<T>

--- a/src/impls/string.rs
+++ b/src/impls/string.rs
@@ -30,13 +30,22 @@ use crate::{Containerized, Push, Region, ReserveItems};
 /// assert_eq!(panagram_de, r.index(de_index));
 /// assert_eq!(panagram_en, r.index(en_index));
 /// ```
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct StringRegion<R = OwnedRegion<u8>>
-where
-    for<'a> R: Region<ReadItem<'a> = &'a [u8]> + 'a,
-{
+pub struct StringRegion<R = OwnedRegion<u8>> {
     inner: R,
+}
+
+impl<R: Clone> Clone for StringRegion<R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner);
+    }
 }
 
 impl<R> Region for StringRegion<R>

--- a/src/impls/tuple.rs
+++ b/src/impls/tuple.rs
@@ -16,10 +16,26 @@ macro_rules! tuple_flatcontainer {
 
             /// A region for a tuple.
             #[allow(non_snake_case)]
-            #[derive(Default, Clone, Debug)]
+            #[derive(Default, Debug)]
             #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
             pub struct [<Tuple $($name)* Region >]<$($name),*> {
                 $([<container $name>]: $name),*
+            }
+
+            #[allow(non_snake_case)]
+            impl<$($name: Region + Clone),*> Clone for [<Tuple $($name)* Region>]<$($name),*>
+            where
+               $(<$name as Region>::Index: crate::Index),*
+            {
+                fn clone(&self) -> Self {
+                    Self {
+                        $([<container $name>]: self.[<container $name>].clone(),)*
+                    }
+                }
+
+                fn clone_from(&mut self, source: &Self) {
+                    $(self.[<container $name>].clone_from(&source.[<container $name>]);)*
+                }
             }
 
             #[allow(non_snake_case)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,11 @@ impl<R: Region + Clone> Clone for FlatStack<R> {
             indices: self.indices.clone(),
         }
     }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.region.clone_from(&source.region);
+        self.indices.clone_from(&source.indices);
+    }
 }
 
 /// A type to wrap and copy iterators onto regions.

--- a/tests/recursive.rs
+++ b/tests/recursive.rs
@@ -78,11 +78,6 @@ where
     type ReadItem<'a> = ListRef<'a, C> where C: 'a;
     type Index = usize;
 
-    fn index(&self, index: Self::Index) -> Self::ReadItem<'_> {
-        let (inner_index, continuation) = self.indexes[index];
-        ListRef(Ok((self, inner_index, continuation)))
-    }
-
     fn merge_regions<'a>(regions: impl Iterator<Item = &'a Self> + Clone) -> Self
     where
         Self: 'a,
@@ -91,6 +86,11 @@ where
             indexes: Vec::with_capacity(regions.clone().map(|r| r.indexes.len()).sum()),
             inner: C::merge_regions(regions.map(|r| &r.inner)),
         }
+    }
+
+    fn index(&self, index: Self::Index) -> Self::ReadItem<'_> {
+        let (inner_index, continuation) = self.indexes[index];
+        ListRef(Ok((self, inner_index, continuation)))
     }
 
     fn reserve_regions<'a, I>(&mut self, regions: I)


### PR DESCRIPTION
Adds proper `Clone` implementations with `clone` and `clone_from` for regions and flat stack. This enables efficient copying of data.
