### PR TITLE
Rename CopyIter to PushIter

### DIFF
--- a/src/impls/storage.rs
+++ b/src/impls/storage.rs
@@ -1,6 +1,6 @@
 //! Storage abstractions to represent slices of data.
 
-use crate::CopyIter;
+use crate::PushIter;
 
 /// Behavior to allocate storage.
 ///
@@ -105,9 +105,9 @@ impl<T: Clone> PushStorage<&[T]> for Vec<T> {
     }
 }
 
-impl<I: IntoIterator<Item = T>, T> PushStorage<CopyIter<I>> for Vec<T> {
+impl<I: IntoIterator<Item = T>, T> PushStorage<PushIter<I>> for Vec<T> {
     #[inline]
-    fn push_storage(&mut self, item: CopyIter<I>) {
+    fn push_storage(&mut self, item: PushIter<I>) {
         self.extend(item.0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,13 +422,13 @@ impl<R: Clone, S: Clone> Clone for FlatStack<R, S> {
     }
 }
 
-/// A type to wrap and copy iterators onto regions.
+/// A type to wrap and push iterators into regions.
 ///
 /// This only exists to avoid blanket implementations that might conflict with more specific
 /// implementations offered by some regions.
 #[repr(transparent)]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-pub struct CopyIter<I>(pub I);
+pub struct PushIter<I>(pub I);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Rename `CopyIter` to `PushIter` to better capture its intentions. Do this now as we're in the middle of breaking changes anyway.
