### PR TITLE
Drop ExactSizeIterator requirement from Index::extend

### DIFF
--- a/src/impls/columns.rs
+++ b/src/impls/columns.rs
@@ -492,7 +492,6 @@ where
     R: Region + Push<T>,
     O: IndexContainer<usize>,
     I: IntoIterator<Item = T>,
-    I::IntoIter: ExactSizeIterator,
 {
     #[inline]
     fn push(&mut self, item: PushIter<I>) -> <ColumnsRegion<R, O> as Region>::Index {

--- a/src/impls/index.rs
+++ b/src/impls/index.rs
@@ -18,11 +18,8 @@ pub trait IndexContainer<T>: Storage<T> {
     /// Accepts a newly pushed element.
     fn push(&mut self, item: T);
 
-    /// Extend from iterator. Must be [`ExactSizeIterator`] to efficiently
-    /// pre-allocate.
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I)
-    where
-        I::IntoIter: ExactSizeIterator;
+    /// Extend from iterator.
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I);
 
     /// Returns an iterator over the elements.
     fn iter(&self) -> Self::Iter<'_>;
@@ -320,8 +317,6 @@ where
 
     #[inline]
     fn extend<I: IntoIterator<Item = usize>>(&mut self, iter: I)
-    where
-        I::IntoIter: ExactSizeIterator,
     {
         for item in iter {
             self.push(item);
@@ -436,8 +431,6 @@ where
     }
 
     fn extend<I: IntoIterator<Item = usize>>(&mut self, iter: I)
-    where
-        I::IntoIter: ExactSizeIterator,
     {
         for item in iter {
             self.push(item);
@@ -483,10 +476,7 @@ impl<T: Copy> IndexContainer<T> for Vec<T> {
         self.push(item);
     }
 
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I)
-    where
-        I::IntoIter: ExactSizeIterator,
-    {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         Extend::extend(self, iter);
     }
 

--- a/src/impls/slice_owned.rs
+++ b/src/impls/slice_owned.rs
@@ -252,7 +252,6 @@ where
 impl<T, S, I> Push<PushIter<I>> for OwnedRegion<T, S>
 where
     I: IntoIterator<Item = T>,
-    <I as IntoIterator>::IntoIter: ExactSizeIterator,
     T: Clone,
     S: Storage<T>
         + PushStorage<PushIter<I>>


### PR DESCRIPTION
It's not used and apparently less reliable than an implementation might assume.
