### PR TITLE
Tests to validate that regions implement a common interface

### DIFF
--- a/tests/useful_types.rs
+++ b/tests/useful_types.rs
@@ -1,0 +1,70 @@
+//! Test that the types defined by this crate are useful, i.e., they
+//! offer implementations over what's absolutely necessary.
+
+use flatcontainer::{
+    ColumnsRegion, MirrorRegion, OptionRegion, OwnedRegion, Push, Region, ReserveItems,
+    ResultRegion, SliceRegion, StringRegion,
+};
+
+trait UsefulRegion:
+    Region
+    + Push<<Self as Region>::Owned>
+    + for<'a> Push<&'a <Self as Region>::Owned>
+    + for<'a> Push<<Self as Region>::ReadItem<'a>>
+    + for<'a> ReserveItems<&'a <Self as Region>::Owned>
+    + for<'a> ReserveItems<<Self as Region>::ReadItem<'a>>
+{
+}
+
+impl<R> UsefulRegion for R where
+    R: Region
+        + Push<<Self as Region>::Owned>
+        + for<'a> Push<&'a <Self as Region>::Owned>
+        + for<'a> Push<<Self as Region>::ReadItem<'a>>
+        + for<'a> ReserveItems<&'a <Self as Region>::Owned>
+        + for<'a> ReserveItems<<Self as Region>::ReadItem<'a>>
+{
+}
+
+trait DerefRegion: UsefulRegion
+where
+    <Self as Region>::Owned: std::ops::Deref,
+    Self: for<'a> Push<&'a <<Self as Region>::Owned as std::ops::Deref>::Target>,
+    Self: for<'a> ReserveItems<&'a <<Self as Region>::Owned as std::ops::Deref>::Target>,
+{
+}
+
+impl<R> DerefRegion for R
+where
+    R: UsefulRegion,
+    <Self as Region>::Owned: std::ops::Deref,
+    Self: for<'a> Push<&'a <<Self as Region>::Owned as std::ops::Deref>::Target>,
+    Self: for<'a> ReserveItems<&'a <<Self as Region>::Owned as std::ops::Deref>::Target>,
+{
+}
+
+#[test]
+fn test_useful_region() {
+    fn _useful_region<R: UsefulRegion>() {}
+    _useful_region::<MirrorRegion<usize>>();
+    _useful_region::<OptionRegion<MirrorRegion<usize>>>();
+    _useful_region::<OwnedRegion<usize>>();
+    _useful_region::<ResultRegion<MirrorRegion<usize>, MirrorRegion<usize>>>();
+    _useful_region::<SliceRegion<MirrorRegion<usize>>>();
+    _useful_region::<StringRegion>();
+    _useful_region::<Vec<usize>>();
+    _useful_region::<ColumnsRegion<MirrorRegion<usize>>>();
+    // _useful_region::<CodecRegion<DictionaryCodec>>();
+}
+
+#[test]
+fn test_deref_region() {
+    fn _deref_region<R: DerefRegion>()
+    where
+        <R as Region>::Owned: std::ops::Deref,
+    {
+    }
+    _deref_region::<OwnedRegion<usize>>();
+    _deref_region::<SliceRegion<MirrorRegion<usize>>>();
+    _deref_region::<StringRegion>();
+}


### PR DESCRIPTION
We don't require region implementations to provide other trait
implementations, but in many cases it is useful to have push/reserve
implementations. This tests checks that regions provided by this crate
provide said implementations. Specifically, it checks that regions can
absorb their owned type, references to their owned type, the read item,
and allow to reserve space for references to the owned type and the read
item. Additionally, regions for where owned types are Deref, the region
should absorb references to the deref target, and be able to reserve it.

This surfaced some missing APIs which we add in this change. Namely, the
columns region missed reserve APIs. Adding the reserve implementations
required the column's item getter to return an option (elements are not
required to have the same length.) The codec region still doesn't provide
all implementations required, but it's closer and provides sufficient
push implementations. It only misses the reserve items API, which does not
make too much sense in its context.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
