### PR TITLE
Switch to patched codspeed binary

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build the codspeed binary
-        run: cargo install cargo-codspeed
+        run: cargo install --git https://github.com/antiguru/codspeed-rust --branch bump_versions
 
       - name: Build the benchmark targets
         run: cargo codspeed build


### PR DESCRIPTION
The current codspeed crate fails to build on Rust 1.80.